### PR TITLE
Add orion:controller & orion:request commands

### DIFF
--- a/src/Commands/OrionControllerMakeCommand.php
+++ b/src/Commands/OrionControllerMakeCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Orion\Commands;
+
+use Illuminate\Routing\Console\ControllerMakeCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class OrionControllerMakeCommand extends ControllerMakeCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'orion:controller';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Orion controller class';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        $stub = null;
+
+        if ($this->option('model')) {
+            $stub = '/stubs/orion.controller.model.stub';
+        }
+
+        $stub = $stub ?? '/stubs/orion.controller.plain.stub';
+
+        return __DIR__.$stub;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
+            ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
+        ];
+    }
+}

--- a/src/Commands/OrionRequestMakeCommand.php
+++ b/src/Commands/OrionRequestMakeCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orion\Commands;
+
+use Illuminate\Foundation\Console\RequestMakeCommand;
+
+class OrionRequestMakeCommand extends RequestMakeCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'orion:request';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Orion request class';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/orion.request.stub';
+    }
+}

--- a/src/Commands/stubs/orion.controller.model.stub
+++ b/src/Commands/stubs/orion.controller.model.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace DummyNamespace;
+
+use Orion\Http\Controllers\Controller;
+use DummyModelClass;
+
+class DummyClass extends Controller
+{
+    protected $model = DummyModelClass::class;
+}

--- a/src/Commands/stubs/orion.controller.plain.stub
+++ b/src/Commands/stubs/orion.controller.plain.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace DummyNamespace;
+
+use Orion\Http\Controllers\Controller;
+
+class DummyClass extends Controller
+{
+
+}

--- a/src/Commands/stubs/orion.request.stub
+++ b/src/Commands/stubs/orion.request.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace DummyNamespace;
+
+use Orion\Http\Requests\Request;
+
+class DummyClass extends Request
+{
+    public function commonRules(): array
+    {
+        return [];
+    }
+
+    public function storeRules(): array
+    {
+        return [];
+    }
+
+    public function updateRules(): array
+    {
+        return [];
+    }
+}

--- a/src/OrionServiceProvider.php
+++ b/src/OrionServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Orion;
 
 use Illuminate\Support\ServiceProvider;
+use Orion\Commands\OrionControllerMakeCommand;
+use Orion\Commands\OrionRequestMakeCommand;
 use Orion\Contracts\ComponentsResolver;
 use Orion\Contracts\Paginator;
 use Orion\Contracts\ParamsValidator;
@@ -36,6 +38,11 @@ class OrionServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->commands([
+            OrionControllerMakeCommand::class,
+            OrionRequestMakeCommand::class,
+        ]);
+
         app('router')->pushMiddlewareToGroup('api', EnforceExpectsJson::class);
     }
 }


### PR DESCRIPTION
Having started using your package, it seemed to me that it lacks the banal generation of controllers and requests. So I implemented two simple commands to do this:
```
php artisan orion:contoller
php artisan orion:request
```