### PR TITLE
fix: ambiguous column sql exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          coverage: none
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
           - php-version: '8.0'
             laravel-version: '^8.0'
             database: 'pgsql'
+          - php-version: '8.0'
+            laravel-version: '^8.0'
+            database: 'mysql'
 
     name: Tests on PHP ${{ matrix.php-version }} with Laravel ${{ matrix.laravel-version }} and ${{ matrix.database }}
 

--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -115,7 +115,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
                     $this->buildFilterQueryWhereClause($relationField, $filterDescriptor, $relationQuery);
                 });
             } else {
-                $this->buildFilterQueryWhereClause($filterDescriptor['field'], $filterDescriptor, $query, $or);
+                $this->buildFilterQueryWhereClause($this->getQualifiedFieldName($filterDescriptor['field']), $filterDescriptor, $query, $or);
             }
         }
     }
@@ -173,7 +173,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
                         return $relationQuery->where($relationField, 'like', '%'.$requestedSearchString.'%');
                     });
                 } else {
-                    $whereQuery->orWhere($searchable, 'like', '%'.$requestedSearchString.'%');
+                    $whereQuery->orWhere($this->getQualifiedFieldName($searchable), 'like', '%'.$requestedSearchString.'%');
                 }
             }
         });
@@ -213,9 +213,9 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
 
                 $query->leftJoin($relationTable, $relationForeignKey, '=', $relationLocalKey)
                     ->orderBy("$relationTable.$relationField", $direction)
-                    ->select((new $this->resourceModelClass)->getTable().'.*');
+                    ->select($this->getQualifiedFieldName('*'));
             } else {
-                $query->orderBy($sortableField, $direction);
+                $query->orderBy($this->getQualifiedFieldName($sortableField), $direction);
             }
         }
     }
@@ -240,5 +240,17 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         }
 
         return true;
+    }
+
+    /**
+     * Builds a complete field name with table.
+     *
+     * @param string $field
+     * @return string
+     */
+    protected function getQualifiedFieldName(string $field): string
+    {
+        $table = (new $this->resourceModelClass)->getTable();
+        return "{$table}.{$field}";
     }
 }

--- a/tests/Feature/StandardIndexFilteringOperationsTest.php
+++ b/tests/Feature/StandardIndexFilteringOperationsTest.php
@@ -19,7 +19,6 @@ class StandardIndexFilteringOperationsTest extends TestCase
 
         Gate::policy(Post::class, GreenPolicy::class);
 
-        $this->withoutExceptionHandling();
         $response = $this->post('/api/posts/search', [
             'filters' => [
                 ['field' => 'title', 'operator' => '=', 'value' => 'match']

--- a/tests/Feature/StandardIndexFilteringOperationsTest.php
+++ b/tests/Feature/StandardIndexFilteringOperationsTest.php
@@ -19,6 +19,7 @@ class StandardIndexFilteringOperationsTest extends TestCase
 
         Gate::policy(Post::class, GreenPolicy::class);
 
+        $this->withoutExceptionHandling();
         $response = $this->post('/api/posts/search', [
             'filters' => [
                 ['field' => 'title', 'operator' => '=', 'value' => 'match']


### PR DESCRIPTION
When two fields with the same name were used from both main and relation resources in filters, search, or sorting, it resulted in ambiguous column sql exception.