### PR TITLE
Remove unnecessary Request fill check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,29 @@ jobs:
             laravel-version: '5.7.*'
             database: 'pgsql'
           - php-version: '8.0'
-            laravel-version: '^8.0'
+            laravel-version: '5.7.*'
+            database: 'sqlite'
+          - php-version: '8.0'
+            laravel-version: '5.7.*'
+            database: 'mysql'
+          - php-version: '8.0'
+            laravel-version: '5.7.*'
+            database: 'pgsql'
+          - php-version: '8.0'
+            laravel-version: '5.8.*'
+            database: 'sqlite'
+          - php-version: '8.0'
+            laravel-version: '5.8.*'
+            database: 'mysql'
+          - php-version: '8.0'
+            laravel-version: '5.8.*'
             database: 'pgsql'
           - php-version: '8.0'
             laravel-version: '^8.0'
             database: 'mysql'
+          - php-version: '8.0'
+            laravel-version: '^8.0'
+            database: 'pgsql'
 
     name: Tests on PHP ${{ matrix.php-version }} with Laravel ${{ matrix.laravel-version }} and ${{ matrix.database }}
 
@@ -83,9 +101,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php-${{ matrix.php-version }}-
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
@@ -95,16 +113,24 @@ jobs:
         if: matrix.laravel-version == '^8.0'
         run: composer require "laravel/legacy-factories" --prefer-dist --no-progress --no-suggest
 
+      - name: Upgrade to PhpUnit 9 for PHP 8
+        if: matrix.laravel-version == '^8.0'
+        run: composer update --with "phpunit/phpunit=^9.0" --prefer-dist --no-progress --no-suggest
+
+      - name: Upgrade PhpUnit Config for PHP 8
+        if: matrix.laravel-version == '^8.0'
+        run: vendor/bin/phpunit -c phpunit.xml.dist --migrate-configuration
+
       - name: Run test suite with Sqlite
         if: matrix.database == 'sqlite'
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit --debug
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: ':memory:'
 
       - name: Run test suite with MySQL
         if: matrix.database == 'mysql'
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit --debug
         env:
           DB_CONNECTION: mysql
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
@@ -113,7 +139,7 @@ jobs:
 
       - name: Run test suite with PostgreSQL
         if: matrix.database == 'pgsql'
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit --debug
         env:
           DB_CONNECTION: pgsql
           DB_PORT: ${{ job.services.pgsql.ports[5432] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
             database: 'pgsql'
           - php-version: '8.0'
             laravel-version: '^8.0'
-            database: 'mysql'
+            database: 'pgsql'
           - php-version: '8.0'
             laravel-version: '^8.0'
-            database: 'pgsql'
+            database: 'mysql'
 
     name: Tests on PHP ${{ matrix.php-version }} with Laravel ${{ matrix.laravel-version }} and ${{ matrix.database }}
 

--- a/src/Concerns/HandlesRelationStandardBatchOperations.php
+++ b/src/Concerns/HandlesRelationStandardBatchOperations.php
@@ -47,7 +47,7 @@ trait HandlesRelationStandardBatchOperations
             $this->beforeSave($request, $entity);
 
             $this->performStore(
-                $request, $parentEntity, $entity, Arr::only($resource, $entity->getFillable()), Arr::get($resource, 'pivot', [])
+                $request, $parentEntity, $entity, $resource, Arr::get($resource, 'pivot', [])
             );
 
             $entity = $this->newRelationQuery($parentEntity)->with($requestedRelations)->find($entity->id);
@@ -132,7 +132,7 @@ trait HandlesRelationStandardBatchOperations
             $this->beforeSave($request, $entity);
 
             $this->performUpdate(
-                $request, $parentEntity, $entity, Arr::only($resource, $entity->getFillable()), Arr::get($resource, 'pivot', [])
+                $request, $parentEntity, $entity, $resource, Arr::get($resource, 'pivot', [])
             );
 
             $entity = $this->newRelationQuery($parentEntity)->with($requestedRelations)->find($entity->id);

--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -149,7 +149,7 @@ trait HandlesRelationStandardOperations
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
 
         $this->performStore(
-            $request, $parentEntity, $entity, $request->only($entity->getFillable()), $request->get('pivot', [])
+            $request, $parentEntity, $entity, $request->all(), $request->get('pivot', [])
         );
 
         $entity = $this->newRelationQuery($parentEntity)->with($requestedRelations)->find($entity->id);
@@ -349,7 +349,7 @@ trait HandlesRelationStandardOperations
             $request,
             $parentEntity,
             $entity,
-            $request->only($entity->getFillable()),
+            $request->all(),
             $request->get('pivot', [])
         );
 

--- a/src/Concerns/HandlesStandardBatchOperations.php
+++ b/src/Concerns/HandlesStandardBatchOperations.php
@@ -5,7 +5,6 @@ namespace Orion\Concerns;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Orion\Http\Requests\Request;
 use Orion\Http\Resources\CollectionResource;
@@ -43,7 +42,7 @@ trait HandlesStandardBatchOperations
             $this->beforeStore($request, $entity);
             $this->beforeSave($request, $entity);
 
-            $this->performStore($request, $entity, Arr::only($resource, $entity->getFillable()));
+            $this->performStore($request, $entity, $resource);
 
             $entity = $entity->fresh($requestedRelations);
             $entity->wasRecentlyCreated = true;
@@ -90,8 +89,7 @@ trait HandlesStandardBatchOperations
             $this->beforeSave($request, $entity);
 
             $this->performUpdate(
-                $request, $entity, Arr::only($request->input("resources.{$entity->getKey()}"),
-                $entity->getFillable())
+                $request, $entity, $request->input("resources.{$entity->getKey()}")
             );
 
             $entity = $entity->fresh($requestedRelations);

--- a/src/Concerns/HandlesStandardOperations.php
+++ b/src/Concerns/HandlesStandardOperations.php
@@ -100,7 +100,7 @@ trait HandlesStandardOperations
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
 
         $this->performStore(
-            $request, $entity, $request->only($entity->getFillable())
+            $request, $entity, $request->all()
         );
 
         $entity = $entity->fresh($requestedRelations);
@@ -218,7 +218,7 @@ trait HandlesStandardOperations
         }
 
         $this->performUpdate(
-            $request, $entity, $request->only($entity->getFillable())
+            $request, $entity, $request->all()
         );
 
         $entity = $entity->fresh($requestedRelations);


### PR DESCRIPTION
Laravel Model's `fill` method already checks and fills keys by the `fillable` and `guarded` attributes.
Hence there is no need to retrieve only `fillable` attributes from the `request` bag, we can let the framework handle it for us.

All tests are passing.

Closes #18 