### PR TITLE
fix: allow recursive validation

### DIFF
--- a/src/Http/Requests/Request.php
+++ b/src/Http/Requests/Request.php
@@ -28,7 +28,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'store') {
-            return array_merge($this->commonRules(), $this->storeRules());
+            return array_merge_recursive($this->commonRules(), $this->storeRules());
         }
 
         if ($this->route()->getActionMethod() === 'batchStore') {
@@ -36,7 +36,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'update') {
-            return array_merge($this->commonRules(), $this->updateRules());
+            return array_merge_recursive($this->commonRules(), $this->updateRules());
         }
 
         if ($this->route()->getActionMethod() === 'batchUpdate') {
@@ -44,7 +44,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'associate') {
-            return array_merge(
+            return array_merge_recursive(
                 [
                     'related_key' => 'required',
                 ],
@@ -53,7 +53,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'attach') {
-            return array_merge(
+            return array_merge_recursive(
                 [
                     'resources' => 'present',
                     'duplicates' => ['sometimes', 'boolean'],
@@ -63,7 +63,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'detach') {
-            return array_merge(
+            return array_merge_recursive(
                 [
                     'resources' => 'present',
                 ],
@@ -72,7 +72,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'sync') {
-            return array_merge(
+            return array_merge_recursive(
                 [
                     'resources' => 'present',
                     'detaching' => ['sometimes', 'boolean'],
@@ -82,7 +82,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'toggle') {
-            return array_merge(
+            return array_merge_recursive(
                 [
                     'resources' => 'present',
                 ],
@@ -91,7 +91,7 @@ class Request extends FormRequest
         }
 
         if ($this->route()->getActionMethod() === 'updatePivot') {
-            return array_merge(
+            return array_merge_recursive(
                 [
                     'pivot' => ['required', 'array'],
                 ],
@@ -128,7 +128,7 @@ class Request extends FormRequest
             'resources' => ['array', 'required'],
         ];
 
-        $mergedRules = array_merge($this->commonRules(), $definedRules, $definedBatchRules);
+        $mergedRules = array_merge_recursive($this->commonRules(), $definedRules, $definedBatchRules);
 
         foreach ($mergedRules as $ruleField => $fieldRules) {
             $batchRules["resources.*.{$ruleField}"] = $fieldRules;

--- a/tests/Unit/Http/Requests/RequestTest.php
+++ b/tests/Unit/Http/Requests/RequestTest.php
@@ -22,7 +22,7 @@ class RequestTest extends TestCase
 
         $this->assertSame(
             [
-                'common-rules-field' => 'required',
+                'common-rules-field' => ['required', 'unique:users,id'],
                 'store-rules-field' => 'required',
             ],
             $stub->rules()
@@ -41,7 +41,7 @@ class RequestTest extends TestCase
 
         $this->assertSame(
             [
-                'common-rules-field' => 'required',
+                'common-rules-field' => ['required', 'max:255'],
                 'update-rules-field' => 'required',
             ],
             $stub->rules()

--- a/tests/Unit/Http/Requests/Stubs/RequestStub.php
+++ b/tests/Unit/Http/Requests/Stubs/RequestStub.php
@@ -26,6 +26,7 @@ class RequestStub extends Request
     public function storeRules(): array
     {
         return [
+            'common-rules-field' => ['unique:users,id'],
             'store-rules-field' => 'required',
         ];
     }
@@ -38,6 +39,7 @@ class RequestStub extends Request
     public function updateRules(): array
     {
         return [
+            'common-rules-field' => ['max:255'],
             'update-rules-field' => 'required',
         ];
     }


### PR DESCRIPTION
Currently, if you have rules in common and in another method, it'll override the latter rather than merging them together, which I believe is the correct behaviour.

Closes #96