### PR TITLE
Prepends 'application/json' to 'Accept' header

### DIFF
--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -211,6 +211,18 @@ trait HandlesRelationStandardOperations
     }
 
     /**
+     * Filters, sorts, and fetches the list of resources.
+     *
+     * @param Request $request
+     * @param $parentKey
+     * @return CollectionResource
+     */
+    public function search(Request $request, $parentKey)
+    {
+        return $this->index($request, $parentKey);
+    }
+
+    /**
      * Create new relation resource.
      *
      * @param Request $request

--- a/src/Http/Middleware/EnforceExpectsJson.php
+++ b/src/Http/Middleware/EnforceExpectsJson.php
@@ -13,10 +13,10 @@ class EnforceExpectsJson
      */
     public function handle(Request $request, $next)
     {
-        if (!$request->expectsJson()) {
+        if (! in_array('application/json', explode(',', $request->header('Accept')))) {
             $request->headers->add(['Accept' => 'application/json,' . $request->header('Accept')]);
         }
-        
+
         return $next($request);
     }
 }

--- a/src/Http/Middleware/EnforceExpectsJson.php
+++ b/src/Http/Middleware/EnforceExpectsJson.php
@@ -13,7 +13,7 @@ class EnforceExpectsJson
      */
     public function handle(Request $request, $next)
     {
-        if (! in_array('application/json', explode(',', $request->header('Accept')))) {
+        if (strpos($request->header('Accept'), 'application/json') !== 0) {
             $request->headers->add(['Accept' => 'application/json,' . $request->header('Accept')]);
         }
 

--- a/src/Http/Middleware/EnforceExpectsJson.php
+++ b/src/Http/Middleware/EnforceExpectsJson.php
@@ -13,7 +13,10 @@ class EnforceExpectsJson
      */
     public function handle(Request $request, $next)
     {
-        $request->headers->add(['Accept' => 'application/json']);
+        if (!$request->expectsJson()) {
+            $request->headers->add(['Accept' => 'application/json,' . $request->header('Accept')]);
+        }
+        
         return $next($request);
     }
 }

--- a/tests/Unit/Http/Middleware/EnforceExpectsJsonTest.php
+++ b/tests/Unit/Http/Middleware/EnforceExpectsJsonTest.php
@@ -16,7 +16,7 @@ class EnforceExpectsJsonTest extends TestCase
         (new EnforceExpectsJson())->handle(
             $request,
             function ($processedRequest) {
-                $this->assertEquals('application/json', $processedRequest->header('Accept'));
+                $this->assertTrue($processedRequest->expectsJson());
             }
         );
     }


### PR DESCRIPTION
I´m having troubles with content negotiation because the original 'Accept' header is lost.

## Scenario
In some routes, I send back different content depending on the 'Accept' header. For example when receiving requests with `application/spec1+json`.


But, because this header is always changed to 'application/json', content negotiation is impossible.

## Proposal

Replace EnforceExpectsJson@handle:

```php
    $request->headers->add(['Accept' => 'application/json']);
```
With:
```php
    if (!$request->expectsJson()) {
        $request->headers->add(['Accept' => 'application/json,' . $request->header('Accept')]);
    }
```

Prepending the mime type on the beginning, so methods like `$request->expectsJson()` will still working.

