### PR TITLE
HandlesRelationStandardOperations->isOneToOneRelation seems to ignore HasOneThrough

### DIFF
--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -526,7 +526,7 @@ trait HandlesRelationStandardOperations
     protected function isOneToOneRelation(Model $parentEntity)
     {
         $relation = $parentEntity->{$this->getRelation()}();
-        return $relation instanceof HasOne || $relation instanceof MorphOne || $relation instanceof BelongsTo;
+        return $relation instanceof HasOne || $relation instanceof MorphOne || $relation instanceof BelongsTo || $relation instanceof HasOneThrough;
     }
 
     /**


### PR DESCRIPTION
Hi,

I have the following situation: 

Model **Document** --> 1:1 --> Model **File** --> 1:1 --> Model **FileContent**. 

My model definition of my **Document** looks like

```php
public function file(): HasOne
{
    return $this->hasOne(File::class);
}

public function filecontent(): HasOneThrough
{
    return $this->hasOneThrough(Filecontent::class, File::class);
}
```

I declared the following routes (routes/api.php):

- Orion::resource('documents', DocumentController::class)
- Orion::hasOneResource('documents', 'file', FileController::class)
- Orion::hasOneThroughResource('documents', 'filecontent', FilecontentController::class)

These declarations result in the following routes:

```
| POST      | api/documents/{document}/file
| DELETE    | api/documents/{document}/file/{file?}
| PUT|PATCH | api/documents/{document}/file/{file?}
| GET|HEAD  | api/documents/{document}/file/{file?}
| POST      | api/documents/{document}/filecontent
| DELETE    | api/documents/{document}/filecontent/{filecontent?}
| GET|HEAD  | api/documents/{document}/filecontent/{filecontent?}
| PUT|PATCH | api/documents/{document}/filecontent/{filecontent?}
```

When I send the PATCH-Request to http://localhost/api/documents/50000/filecontent (where 50000 is the ID of my Document model), I get the following error response:

```json
{
    "message": "Relation key is required, if relation type is not one-to-one",
    "exception": "InvalidArgumentException",
}
```

Please check, if my fix is okay for you (and save enough :-))
