### PR TITLE
Add parent entity to the model policy where possible

### DIFF
--- a/src/Concerns/HandlesRelationManyToManyOperations.php
+++ b/src/Concerns/HandlesRelationManyToManyOperations.php
@@ -632,7 +632,7 @@ trait HandlesRelationManyToManyOperations
         $query = $this->buildShowFetchQuery($request, $parentEntity, []);
         $entity = $this->runShowFetchQuery($request, $query, $parentEntity, $relatedKey);
 
-        $this->authorize('update', $entity);
+        $this->authorize('update', [$entity, $parentEntity]);
 
         $updateResult = $this->performUpdatePivot($request, $parentEntity, $relatedKey, $request->get('pivot', []));
 

--- a/src/Concerns/HandlesRelationOneToManyOperations.php
+++ b/src/Concerns/HandlesRelationOneToManyOperations.php
@@ -52,7 +52,7 @@ trait HandlesRelationOneToManyOperations
         }
 
         $this->authorize('view', $parentEntity);
-        $this->authorize('update', $entity);
+        $this->authorize('update', [$entity, $parentEntity]);
 
         $this->performAssociate($request, $parentEntity, $entity);
 
@@ -204,7 +204,7 @@ trait HandlesRelationOneToManyOperations
             return $beforeHookResult;
         }
 
-        $this->authorize('update', $entity);
+        $this->authorize('update', [$entity, $parentEntity]);
 
         $this->performDissociate($request, $parentEntity, $entity);
 

--- a/src/Concerns/HandlesRelationStandardBatchOperations.php
+++ b/src/Concerns/HandlesRelationStandardBatchOperations.php
@@ -41,12 +41,12 @@ trait HandlesRelationStandardBatchOperations
      */
     protected function batchStoreWithTransaction(Request $request, $parentKey)
     {
-        $resourceModelClass = $this->resolveResourceModelClass();
-
-        $this->authorize('create', $resourceModelClass);
-
         $parentQuery = $this->buildBatchStoreParentFetchQuery($request, $parentKey);
         $parentEntity = $this->runBatchStoreParentFetchQuery($request, $parentQuery, $parentKey);
+
+        $resourceModelClass = $this->resolveResourceModelClass();
+
+        $this->authorize('create', [$resourceModelClass, $parentEntity]);
 
         $beforeHookResult = $this->beforeBatchStore($request, $parentEntity);
         if ($this->hookResponds($beforeHookResult)) {
@@ -194,7 +194,7 @@ trait HandlesRelationStandardBatchOperations
 
         foreach ($entities as $entity) {
             /** @var Model $entity */
-            $this->authorize('update', $entity);
+            $this->authorize('update', [$entity, $parentEntity]);
 
             $resource = $request->input("resources.{$entity->{$this->keyName()}}");
 
@@ -393,7 +393,7 @@ trait HandlesRelationStandardBatchOperations
 
         foreach ($entities as $entity) {
             /** @var Model $entity */
-            $this->authorize($forceDeletes ? 'forceDelete' : 'delete', $entity);
+            $this->authorize($forceDeletes ? 'forceDelete' : 'delete', [$entity, $parentEntity]);
 
             $this->beforeDestroy($request, $parentEntity, $entity);
 
@@ -560,7 +560,7 @@ trait HandlesRelationStandardBatchOperations
 
         foreach ($entities as $entity) {
             /** @var Model $entity */
-            $this->authorize('restore', $entity);
+            $this->authorize('restore', [$entity, $parentEntity]);
 
             $this->beforeRestore($request, $parentEntity, $entity);
 

--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -32,12 +32,12 @@ trait HandlesRelationStandardOperations
      */
     public function index(Request $request, $parentKey)
     {
-        $this->authorize('viewAny', $this->resolveResourceModelClass());
-
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
 
         $parentQuery = $this->buildIndexParentFetchQuery($request, $parentKey);
         $parentEntity = $this->runIndexParentFetchQuery($request, $parentQuery, $parentKey);
+
+        $this->authorize('viewAny', [$this->resolveResourceModelClass(), $parentEntity]);
 
         $beforeHookResult = $this->beforeIndex($request, $parentEntity);
         if ($this->hookResponds($beforeHookResult)) {
@@ -251,12 +251,12 @@ trait HandlesRelationStandardOperations
      */
     protected function storeWithTransaction(Request $request, $parentKey)
     {
-        $resourceModelClass = $this->resolveResourceModelClass();
-
-        $this->authorize('create', $resourceModelClass);
-
         $parentQuery = $this->buildStoreParentFetchQuery($request, $parentKey);
         $parentEntity = $this->runStoreParentFetchQuery($request, $parentQuery, $parentKey);
+
+        $resourceModelClass = $this->resolveResourceModelClass();
+
+        $this->authorize('create', [$resourceModelClass, $parentEntity]);
 
         /** @var Model $entity */
         $entity = new $resourceModelClass;
@@ -434,7 +434,7 @@ trait HandlesRelationStandardOperations
         $query = $this->buildShowFetchQuery($request, $parentEntity, $requestedRelations);
         $entity = $this->runShowFetchQuery($request, $query, $parentEntity, $relatedKey);
 
-        $this->authorize('view', $entity);
+        $this->authorize('view', [$entity, $parentEntity]);
 
         $entity = $this->cleanupEntity($entity);
 
@@ -613,7 +613,7 @@ trait HandlesRelationStandardOperations
         $query = $this->buildUpdateFetchQuery($request, $parentEntity, $requestedRelations);
         $entity = $this->runUpdateFetchQuery($request, $query, $parentEntity, $relatedKey);
 
-        $this->authorize('update', $entity);
+        $this->authorize('update', [$entity, $parentEntity]);
 
         $beforeHookResult = $this->beforeUpdate($request, $parentEntity, $entity);
         if ($this->hookResponds($beforeHookResult)) {
@@ -811,7 +811,7 @@ trait HandlesRelationStandardOperations
             abort(404);
         }
 
-        $this->authorize($forceDeletes ? 'forceDelete' : 'delete', $entity);
+        $this->authorize($forceDeletes ? 'forceDelete' : 'delete', [$entity, $parentEntity]);
 
         $beforeHookResult = $this->beforeDestroy($request, $parentEntity, $entity);
         if ($this->hookResponds($beforeHookResult)) {
@@ -994,7 +994,7 @@ trait HandlesRelationStandardOperations
         $query = $this->buildRestoreFetchQuery($request, $parentEntity, $requestedRelations);
         $entity = $this->runRestoreFetchQuery($request, $query, $parentEntity, $relatedKey);
 
-        $this->authorize('restore', $entity);
+        $this->authorize('restore', [$entity, $parentEntity]);
 
         $beforeHookResult = $this->beforeRestore($request, $parentEntity, $entity);
         if ($this->hookResponds($beforeHookResult)) {


### PR DESCRIPTION
This change allows for model policies to also check the parent model for authorization

Below is an example of what is possible with this change.
```php

class PostPolicy {
    public function update($user, $team)
    {
        return $team->user_id === $user->id;
    }
}

class PostMetaPolicy {
    public function update($user, $postMeta, $post)
    {
        return Gate::forUser($user)->inspect('update', $post);
    }
    public function create($user, $post)
    {
        return Gate::forUser($user)->inspect('update', $post);
    }
}
```

This is completely backwards compatible and lets the user decide if he wants to check the parent relation.