### PR TITLE
Fix IDE static method call error

### DIFF
--- a/src/Facades/Orion.php
+++ b/src/Facades/Orion.php
@@ -5,18 +5,18 @@ namespace Orion\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration hasOneResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration belongsToResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration hasManyResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration belongsToManyResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration hasOneThroughResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration hasManyThroughResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration morphOneResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration morphManyResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration morphToResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration morphToManyResource(string $resource, string $relation, string $controller, array $options = [])
- * @method \Illuminate\Routing\PendingResourceRegistration morphByManyResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration hasOneResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration belongsToResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration hasManyResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration belongsToManyResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration hasOneThroughResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration hasManyThroughResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration morphOneResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration morphManyResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration morphToResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration morphToManyResource(string $resource, string $relation, string $controller, array $options = [])
+ * @method static \Illuminate\Routing\PendingResourceRegistration morphByManyResource(string $resource, string $relation, string $controller, array $options = [])
  *
  * @see \Orion\Orion
  */


### PR DESCRIPTION
This PR fixes an IDE bug introduced by #141 whereby IDE's such as PHPStorm complain about calling the Facade methods statically.

<img width="729" alt="Screenshot 2022-01-09 at 13 20 28" src="https://user-images.githubusercontent.com/7163152/148683878-c3318f5b-4a77-4e76-8998-e49db852f85d.png">
