### PR TITLE
Make operator optional in filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
         "symfony/yaml": "^5.3"
     },
     "require-dev": {
+        "laravel/legacy-factories": "^1.3",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0",
-        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0"
+        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "symfony/yaml": "^5.3"
     },
     "require-dev": {
-        "laravel/legacy-factories": "^1.3",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0"

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -53,7 +53,7 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
                 'filters' => ['sometimes', 'array'],
                 'filters.*.type' => ['sometimes', 'in:and,or'],
                 'filters.*.field' => ['required_with:filters', 'regex:/^[\w.\_\-\>]+$/', new WhitelistedField($this->filterableBy)],
-                'filters.*.operator' => ['required_with:filters', 'in:<,<=,>,>=,=,!=,like,not like,ilike,not ilike,in,not in'],
+                'filters.*.operator' => ['sometimes', 'in:<,<=,>,>=,=,!=,like,not like,ilike,not ilike,in,not in'],
                 'filters.*.value' => ['present', 'nullable'],
             ]
         )->validate();

--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -187,7 +187,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         if (!is_array($filterDescriptor['value']) || $constraint === 'whereDate') {
             $query->{$or ? 'or' . ucfirst($constraint) : $constraint}(
                 $field,
-                $filterDescriptor['operator'],
+                $filterDescriptor['operator'] ?? '=',
                 $filterDescriptor['value']
             );
         } else {
@@ -258,14 +258,14 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
             $query->addNestedWhereQuery(
                 $query->newPivotStatement()->whereDate(
                     $query->getTable().".{$field}",
-                    $filterDescriptor['operator'],
+                    $filterDescriptor['operator'] ?? '=',
                     $filterDescriptor['value']
                 )
             );
         } elseif (!is_array($filterDescriptor['value'])) {
             $query->{$or ? 'orWherePivot' : 'wherePivot'}(
                 $field,
-                $filterDescriptor['operator'],
+                $filterDescriptor['operator'] ?? '=',
                 $filterDescriptor['value']
             );
         } else {

--- a/src/Specs/Builders/Partials/RequestBody/Search/FiltersBuilder.php
+++ b/src/Specs/Builders/Partials/RequestBody/Search/FiltersBuilder.php
@@ -36,7 +36,7 @@ class FiltersBuilder extends SearchPartialBuilder
                     ]
                 ],
                 'required' => [
-                    'field', 'operator', 'value'
+                    'field', 'value'
                 ]
             ]
         ];

--- a/tests/Feature/StandardIndexFilteringOperationsTest.php
+++ b/tests/Feature/StandardIndexFilteringOperationsTest.php
@@ -13,6 +13,29 @@ use Orion\Tests\Fixtures\App\Policies\GreenPolicy;
 class StandardIndexFilteringOperationsTest extends TestCase
 {
     /** @test */
+    public function getting_a_list_of_resources_filtered_by_model_field_using_default_operator(): void
+    {
+        $matchingPost = factory(Post::class)->create(['title' => 'match'])->fresh();
+        factory(Post::class)->create(['title' => 'not match'])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/posts/search',
+            [
+                'filters' => [
+                    ['field' => 'title', 'value' => 'match'],
+                ],
+            ]
+        );
+
+        $this->assertResourcesPaginated(
+            $response,
+            $this->makePaginator([$matchingPost], 'posts/search')
+        );
+    }
+
+    /** @test */
     public function getting_a_list_of_resources_filtered_by_model_field_using_equal_operator(): void
     {
         $matchingPost = factory(Post::class)->create(['title' => 'match'])->fresh();


### PR DESCRIPTION
In order to be compliant with Laravel query builder `where` method, this PR makes operator field optional in filters.
Default value is `=`.

PS i added `laravel/legacy-factories` in dev dependecies in order to make this package testable on new Laravel version