### PR TITLE
chore: allow higher version of `symfony/yaml` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/http": ">=5.7",
         "illuminate/pagination": ">=5.7",
         "illuminate/support": ">=5.7",
-        "symfony/yaml": "^5.3"
+        "symfony/yaml": "^5.3|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
If a certain project already had `orchestra/testbench` package v7.0 or above installed, this package cannot be installed because `symfony/yaml` package v6.0 or above is in the lock file. I have also tried `composer require tailflow/laravel-orion -W` and does not work. This PR fixes that problem.