### PR TITLE
Add default tags config

### DIFF
--- a/config/orion.php
+++ b/config/orion.php
@@ -27,6 +27,7 @@ return [
         'servers' => [
             ['url' => env('APP_URL').'/api', 'description' => 'Default Environment'],
         ],
+        'tags' => []
     ],
     'transactions' => [
         'enabled' => false,

--- a/src/Specs/Builders/TagsBuilder.php
+++ b/src/Specs/Builders/TagsBuilder.php
@@ -21,11 +21,12 @@ class TagsBuilder
     public function build(): array
     {
         $resources = $this->resourcesCacheStore->getResources();
-        $tags = collect([]);
+        $tags = collect(config('orion.specs.tags'));
 
         foreach ($resources as $resource) {
             $tags[] = [
-                'name' => $resource->tag
+                'name'        => $resource->tag,
+                'description' => "API documentation for {$resource->tag}",
             ];
         }
 


### PR DESCRIPTION
Motivation:
Sometimes we need to add extra tags to the specs but the merge of this tag property doesn't work very well.
Some documentation tools like redoc use these tags to add sections to the documentation. Something like that:
![image](https://user-images.githubusercontent.com/11599205/155425956-3ce4c021-13aa-4b17-9fb6-31684c5526a9.png)
