### PR TITLE
:sparkles: nested filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.3",
         "ext-json": "*",
         "doctrine/dbal": "^2.9|^3.1",
         "illuminate/bus": ">=5.7",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-json": "*",
         "doctrine/dbal": "^2.9|^3.1",
         "illuminate/bus": ">=5.7",

--- a/config/orion.php
+++ b/config/orion.php
@@ -34,20 +34,19 @@ return [
     ],
     'search' => [
         'case_sensitive' => true, // TODO: set to "false" by default in 3.0 release
+            /*
+            |--------------------------------------------------------------------------
+            | Max Nested Depth
+            |--------------------------------------------------------------------------
+            |
+            | This value is the maximum depth of nested filters
+            | you will most likely need this to be maximum at 1 but
+            | you can increase this number if necessary. Please
+            | be aware that the depth generate dynamic rules and can slow
+            | your application if someone sends a request with thousands of nested
+            | filters.
+            |
+            */
+        'max_nested_depth' => 1
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Max Nested Depth
-    |--------------------------------------------------------------------------
-    |
-    | This value is the maximum depth of nested filters
-    | you will most likely need this to be maximum at 1 but
-    | you can increase this number if necessary. Please
-    | be aware that the depth generate dynamic rules and can slow
-    | your application if someone sends a request with thousands of nested
-    | filters.
-    |
-    */
-    'max_nested_depth' => 1
 ];

--- a/config/orion.php
+++ b/config/orion.php
@@ -34,5 +34,6 @@ return [
     ],
     'search' => [
         'case_sensitive' => true, // TODO: set to "false" by default in 3.0 release
-    ]
+    ],
+    'max_nested_depth' => 1
 ];

--- a/config/orion.php
+++ b/config/orion.php
@@ -35,5 +35,19 @@ return [
     'search' => [
         'case_sensitive' => true, // TODO: set to "false" by default in 3.0 release
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Max Nested Depth
+    |--------------------------------------------------------------------------
+    |
+    | This value is the maximum depth of nested filters
+    | you will most likely need this to be maximum at 1 but
+    | you can increase this number if necessary. Please
+    | be aware that the depth generate dynamic rules and can slow
+    | your application if someone sends a request with thousands of nested
+    | filters.
+    |
+    */
     'max_nested_depth' => 1
 ];

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -47,7 +47,7 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
 
     public function validateFilters(Request $request): void
     {
-        $max_depth = ceil(($this->getArrayDepth($request->all()['filters'])) / 2) - 1;
+        $max_depth = floor($this->getArrayDepth($request->all()['filters']) / 2);
         $config_max_nested_depth = config('orion.search.max_nested_depth', 1);
 
         abort_if($max_depth > $config_max_nested_depth, 422, __('Max nested depth :depth is exceeded', ['depth' => $config_max_nested_depth]));

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -72,7 +72,7 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
                 'in:<,<=,>,>=,=,!=,like,not like,ilike,not ilike,in,not in,all in,any in',
             ],
             $prefix.'.*.value' => ['nullable'],
-            $prefix.'.*.nested' => ['sometimes', 'array', "prohibits:{$prefix}.*.operator,{$prefix}.*.value"],
+            $prefix.'.*.nested' => ['sometimes', 'array', "prohibits:{$prefix}.*.operator,{$prefix}.*.value,{$prefix}.*.field"],
         ]);
 
         if ($max_depth >= $current_depth) {

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -49,7 +49,7 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
     {
         $max_depth = ceil(($this->getArrayDepth($request->all()['filters'])) / 2) - 1;
 
-        abort_if($max_depth > config('orion.max_nested_depth'), 422, __('Max nested depth :depth is exceeded', ['depth' => config('orion.max_nested_depth')]));
+        abort_if($max_depth > config('orion.search.max_nested_depth'), 422, __('Max nested depth :depth is exceeded', ['depth' => config('orion.search.max_nested_depth')]));
 
         Validator::make(
             $request->all(),

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -48,8 +48,9 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
     public function validateFilters(Request $request): void
     {
         $max_depth = ceil(($this->getArrayDepth($request->all()['filters'])) / 2) - 1;
+        $config_max_nested_depth = config('orion.search.max_nested_depth', 1);
 
-        abort_if($max_depth > config('orion.search.max_nested_depth'), 422, __('Max nested depth :depth is exceeded', ['depth' => config('orion.search.max_nested_depth')]));
+        abort_if($max_depth > $config_max_nested_depth, 422, __('Max nested depth :depth is exceeded', ['depth' => $config_max_nested_depth]));
 
         Validator::make(
             $request->all(),

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -53,7 +53,6 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
                 'filters' => ['sometimes', 'array'],
                 'filters.*.type' => ['sometimes', 'in:and,or'],
                 'filters.*.field' => [
-                    'required_with:filters',
                     'regex:/^[\w.\_\-\>]+$/',
                     new WhitelistedField($this->filterableBy),
                 ],

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -68,10 +68,11 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
                 new WhitelistedField($this->filterableBy),
             ],
             $prefix.'.*.operator' => [
+                "prohibited_if:{$prefix}.*.nested",
                 'sometimes',
                 'in:<,<=,>,>=,=,!=,like,not like,ilike,not ilike,in,not in,all in,any in',
             ],
-            $prefix.'.*.value' => ["required_without:{$prefix}.*.nested", 'nullable'],
+            $prefix.'.*.value' => ["prohibited_if:{$prefix}.*.nested", 'nullable'],
             $prefix.'.*.nested' => ['sometimes', 'array'],
         ]);
 

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -68,12 +68,11 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
                 new WhitelistedField($this->filterableBy),
             ],
             $prefix.'.*.operator' => [
-                "prohibited_if:{$prefix}.*.nested",
                 'sometimes',
                 'in:<,<=,>,>=,=,!=,like,not like,ilike,not ilike,in,not in,all in,any in',
             ],
-            $prefix.'.*.value' => ["prohibited_if:{$prefix}.*.nested", 'nullable'],
-            $prefix.'.*.nested' => ['sometimes', 'array'],
+            $prefix.'.*.value' => ['nullable'],
+            $prefix.'.*.nested' => ['sometimes', 'array', "prohibits:{$prefix}.*.operator,{$prefix}.*.value"],
         ]);
 
         if ($max_depth >= $current_depth) {

--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -116,7 +116,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         foreach ($filterDescriptors as $filterDescriptor) {
             $or = Arr::get($filterDescriptor, 'type', 'and') === 'or';
 
-            if (is_array($childrenDescriptors = Arr::get($filterDescriptor, 'value'))) {
+            if (is_array($childrenDescriptors = Arr::get($filterDescriptor, 'nested'))) {
                 $query->{$or ? 'orWhere' : 'where'}(fn ($query) => $this->applyFiltersToQuery($query, $request, $childrenDescriptors));
             } elseif (strpos($filterDescriptor['field'], '.') !== false) {
                 $relation = $this->relationsResolver->relationFromParamConstraint($filterDescriptor['field']);

--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -116,7 +116,9 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         foreach ($filterDescriptors as $filterDescriptor) {
             $or = Arr::get($filterDescriptor, 'type', 'and') === 'or';
 
-            if (strpos($filterDescriptor['field'], '.') !== false) {
+            if (is_array($childrenDescriptors = Arr::get($filterDescriptor, 'value'))) {
+                $query->{$or ? 'orWhere' : 'where'}(fn ($query) => $this->applyFiltersToQuery($query, $request, $childrenDescriptors));
+            } elseif (strpos($filterDescriptor['field'], '.') !== false) {
                 $relation = $this->relationsResolver->relationFromParamConstraint($filterDescriptor['field']);
                 $relationField = $this->relationsResolver->relationFieldFromParamConstraint($filterDescriptor['field']);
 

--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -117,7 +117,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
             $or = Arr::get($filterDescriptor, 'type', 'and') === 'or';
 
             if (is_array($childrenDescriptors = Arr::get($filterDescriptor, 'nested'))) {
-                $query->{$or ? 'orWhere' : 'where'}(fn ($query) => $this->applyFiltersToQuery($query, $request, $childrenDescriptors));
+                $query->{$or ? 'orWhere' : 'where'}(function ($query) use ($request, $childrenDescriptors) { $this->applyFiltersToQuery($query, $request, $childrenDescriptors); });
             } elseif (strpos($filterDescriptor['field'], '.') !== false) {
                 $relation = $this->relationsResolver->relationFromParamConstraint($filterDescriptor['field']);
                 $relationField = $this->relationsResolver->relationFieldFromParamConstraint($filterDescriptor['field']);

--- a/src/Specs/Builders/Partials/RequestBody/Search/FiltersBuilder.php
+++ b/src/Specs/Builders/Partials/RequestBody/Search/FiltersBuilder.php
@@ -14,29 +14,39 @@ class FiltersBuilder extends SearchPartialBuilder
             return null;
         }
 
+        $filters = [
+            'type' => [
+                'type' => 'string',
+                'enum' => ['and', 'or'],
+            ],
+            'field' => [
+                'type' => 'string',
+                'enum' => $this->controller->filterableBy(),
+            ],
+            'operator' => [
+                'type' => 'string',
+                'enum' => ['<','<=','>','>=','=','!=','like','not like','ilike','not ilike','in','not in', 'all in', 'any in'],
+            ],
+            'value' => [
+                'type' => 'string',
+            ]
+        ];
+
         return [
             'type' => 'array',
             'items' => [
                 'type' => 'object',
                 'properties' => [
-                    'type' => [
-                        'type' => 'string',
-                        'enum' => ['and', 'or'],
-                    ],
-                    'field' => [
-                        'type' => 'string',
-                        'enum' => $this->controller->filterableBy(),
-                    ],
-                    'operator' => [
-                        'type' => 'string',
-                        'enum' => ['<','<=','>','>=','=','!=','like','not like','ilike','not ilike','in','not in', 'all in', 'any in'],
-                    ],
-                    'value' => [
-                        'type' => 'string',
+                    ...$filters,
+                    'nested' => [
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'object',
+                            'properties' => [
+                                ...$filters,
+                            ]
+                        ]
                     ]
-                ],
-                'required' => [
-                    'field', 'value'
                 ]
             ]
         ];

--- a/src/Specs/Builders/Partials/RequestBody/Search/FiltersBuilder.php
+++ b/src/Specs/Builders/Partials/RequestBody/Search/FiltersBuilder.php
@@ -36,18 +36,15 @@ class FiltersBuilder extends SearchPartialBuilder
             'type' => 'array',
             'items' => [
                 'type' => 'object',
-                'properties' => [
-                    ...$filters,
+                'properties' => array_merge($filters, [
                     'nested' => [
                         'type' => 'array',
                         'items' => [
                             'type' => 'object',
-                            'properties' => [
-                                ...$filters,
-                            ]
+                            'properties' => $filters
                         ]
                     ]
-                ]
+                ])
             ]
         ];
     }

--- a/tests/Feature/StandardIndexNestedFilteringOperationsTest.php
+++ b/tests/Feature/StandardIndexNestedFilteringOperationsTest.php
@@ -111,6 +111,6 @@ class StandardIndexNestedFilteringOperationsTest extends TestCase
         );
 
         $response->assertStatus(422);
-        $response->assertJsonStructure(['message', 'errors' => ['field']]);
+        $response->assertJsonStructure(['message', 'errors' => ['filters.0.nested.0.field']]);
     }
 }

--- a/tests/Feature/StandardIndexNestedFilteringOperationsTest.php
+++ b/tests/Feature/StandardIndexNestedFilteringOperationsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Orion\Tests\Feature;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Gate;
+use Orion\Tests\Fixtures\App\Models\Company;
+use Orion\Tests\Fixtures\App\Models\Post;
+use Orion\Tests\Fixtures\App\Models\Team;
+use Orion\Tests\Fixtures\App\Models\User;
+use Orion\Tests\Fixtures\App\Policies\GreenPolicy;
+
+class StandardIndexNestedFilteringOperationsTest extends TestCase
+{
+    /** @test */
+    public function getting_a_list_of_resources_nested_filtered_by_model_field_using_default_operator(): void
+    {
+        $matchingPost = factory(Post::class)->create(['title' => 'match'])->fresh();
+        factory(Post::class)->create(['title' => 'not match'])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/posts/search',
+            [
+                'filters' => [
+                    ['field' => 'title', 'operator' => 'in' ,'value' => ['match', 'not_match']],
+                    ['nested' => [
+                        ['field' => 'title', 'value' => 'match'],
+                        ['field' => 'title', 'operator' => '!=', 'value' => 'not match']
+                    ]],
+                ],
+            ]
+        );
+
+        $this->assertResourcesPaginated(
+            $response,
+            $this->makePaginator([$matchingPost], 'posts/search')
+        );
+    }
+
+    /** @test */
+    public function getting_a_list_of_resources_nested_filtered_by_model_field_using_equal_operator_and_or_type(): void
+    {
+        $matchingPost = factory(Post::class)->create(['title' => 'match'])->fresh();
+        $anotherMatchingPost = factory(Post::class)->create(['position' => 3])->fresh();
+        factory(Post::class)->create(['title' => 'not match'])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/posts/search',
+            [
+                'filters' => [
+                    ['field' => 'title', 'operator' => '=', 'value' => 'match'],
+                    ['type' => 'or', 'nested' => [
+                        ['field' => 'position', 'operator' => '=', 'value' => 3],
+                    ]],
+                ],
+            ]
+        );
+
+        $this->assertResourcesPaginated(
+            $response,
+            $this->makePaginator([$matchingPost, $anotherMatchingPost], 'posts/search')
+        );
+    }
+
+    /** @test */
+    public function getting_a_list_of_resources_nested_filtered_by_model_field_using_not_equal_operator(): void
+    {
+        $matchingPost = factory(Post::class)->create(['position' => 4])->fresh();
+        factory(Post::class)->create(['position' => 5])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/posts/search',
+            [
+                'filters' => [
+                    ['nested' => [
+                        ['field' => 'position', 'operator' => '!=', 'value' => 5]
+                    ]],
+                ],
+            ]
+        );
+
+        $this->assertResourcesPaginated(
+            $response,
+            $this->makePaginator([$matchingPost], 'posts/search')
+        );
+    }
+
+    /** @test */
+    public function getting_a_list_of_resources_nested_filtered_by_not_whitelisted_field(): void
+    {
+        factory(Post::class)->create(['body' => 'match'])->fresh();
+        factory(Post::class)->create(['body' => 'not match'])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/posts/search',
+            [
+                'filters' => [
+                    ['nested' => [
+                        ['field' => 'body', 'operator' => '=', 'value' => 'match']
+                    ]],
+                ],
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure(['message', 'errors' => ['field']]);
+    }
+}

--- a/tests/Fixtures/app/Providers/OrionServiceProvider.php
+++ b/tests/Fixtures/app/Providers/OrionServiceProvider.php
@@ -45,6 +45,8 @@ class OrionServiceProvider extends ServiceProvider
     {
         app()->make(Kernel::class)->pushMiddleware(EnforceExpectsJson::class);
 
+        $this->mergeConfigFrom(__DIR__ . '/../../../../config/orion.php', 'orion');
+
         $this->loadRoutesFrom(__DIR__.'/../../routes/api.php');
     }
 }


### PR DESCRIPTION
Hello there,

We are having some trouble using orion because you basically can't handle priority on "or" and "and" on sql queries. This is problematic for us and we really need this to avoid custom routes on our project.

Here is my proposition for adding nested filters.

**What does it do ?**

This PR allows to add nested filters infinitely. Example of a search query:

```json
{
    "filters": [
        {"field": "is_for_all", "value": "true"},
        {
            "value": [
                {"field": "started_at", "operator": ">=", "value": "2022-05-23"},
                {"field": "ended_at", "operator": "<=", "value": "2022-06-23", "type": "or"}
            ],
            "type": "or"
        }
    ]
}
```

Your plugin is really well developed, it was really easy to implement.

**QUESTIONS:**

Do you have any idea how we could validate infinite arrays ? I basically removed requirement on filters and did not add nested validation.

There is a part in the app with "scopedFilters" and "filtersBuilder". It seems like replicating the Orion logic.Is it for open Api ? I did not took time to look at it and update it because i wanted your feedback on it.

Waiting for your feedback.

closes #126