### PR TITLE
fixes Undefined array key "filters" error

### DIFF
--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -47,7 +47,7 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
 
     public function validateFilters(Request $request): void
     {
-        $maxDepth = floor($this->getArrayDepth($request->all()['filters']) / 2);
+        $maxDepth = floor($this->getArrayDepth($request->input('filters', [])) / 2);
         $configMaxNestedDepth = config('orion.search.max_nested_depth', 1);
 
         abort_if(


### PR DESCRIPTION
After the release of nested filters I got this error:

```
Undefined array key "filters"
```

This PR fixes it.
