### PR TITLE
Use validated() instead of all() for resources data

### DIFF
--- a/config/orion.php
+++ b/config/orion.php
@@ -49,4 +49,6 @@ return [
          */
         'max_nested_depth' => 1,
     ],
+
+    'use_validated' => false,
 ];

--- a/src/Concerns/HandlesRelationManyToManyOperations.php
+++ b/src/Concerns/HandlesRelationManyToManyOperations.php
@@ -54,7 +54,9 @@ trait HandlesRelationManyToManyOperations
         $attachResult = $this->performAttach(
             $request,
             $parentEntity,
-            $request->get('resources'),
+            config('orion.use_validated')
+                ? $request->validated('resources')
+                : $request->get('resources'),
             $request->get('duplicates', false)
         );
 
@@ -271,7 +273,13 @@ trait HandlesRelationManyToManyOperations
 
         $this->authorize('update', $parentEntity);
 
-        $detachResult = $this->performDetach($request, $parentEntity, $request->get('resources'));
+        $detachResult = $this->performDetach(
+            $request,
+            $parentEntity,
+            config('orion.use_validated')
+                ? $request->validated('resources')
+                : $request->get('resources')
+        );
 
         $afterHookResult = $this->afterDetach($request, $parentEntity, $detachResult);
         if ($this->hookResponds($afterHookResult)) {
@@ -393,7 +401,9 @@ trait HandlesRelationManyToManyOperations
         $syncResult = $this->performSync(
             $request,
             $parentEntity,
-            $request->get('resources'),
+            config('orion.use_validated')
+                ? $request->validated('resources')
+                : $request->get('resources'),
             $request->get('detaching', true)
         );
 
@@ -516,7 +526,13 @@ trait HandlesRelationManyToManyOperations
 
         $this->authorize('update', $parentEntity);
 
-        $toggleResult = $this->performToggle($request, $parentEntity, $request->get('resources'));
+        $toggleResult = $this->performToggle(
+            $request,
+            $parentEntity,
+            config('orion.use_validated')
+                ? $request->validated('resources')
+                : $request->get('resources')
+        );
 
         $afterHookResult = $this->afterToggle($request, $parentEntity, $toggleResult);
         if ($this->hookResponds($afterHookResult)) {

--- a/src/Concerns/HandlesRelationStandardBatchOperations.php
+++ b/src/Concerns/HandlesRelationStandardBatchOperations.php
@@ -53,7 +53,9 @@ trait HandlesRelationStandardBatchOperations
             return $beforeHookResult;
         }
 
-        $resources = $request->get('resources', []);
+        $resources = config('orion.use_validated')
+            ? $request->validated('resources', [])
+            : $request->get('resources', []);
         $entities = collect([]);
 
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
@@ -196,7 +198,9 @@ trait HandlesRelationStandardBatchOperations
             /** @var Model $entity */
             $this->authorize('update', [$entity, $parentEntity]);
 
-            $resource = $request->input("resources.{$entity->{$this->keyName()}}");
+            $resource = config('orion.use_validated')
+                ? $request->validated("resources.{$entity->{$this->keyName()}}")
+                : $request->input("resources.{$entity->{$this->keyName()}}");
 
             $this->beforeUpdate($request, $parentEntity, $entity);
             $this->beforeSave($request, $parentEntity, $entity);

--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -284,7 +284,9 @@ trait HandlesRelationStandardOperations
             $request,
             $parentEntity,
             $entity,
-            $request->all(),
+            config('orion.use_validated')
+                ? $request->validated()
+                : $request->all(),
             $request->get('pivot', [])
         );
 
@@ -636,7 +638,9 @@ trait HandlesRelationStandardOperations
             $request,
             $parentEntity,
             $entity,
-            $request->all(),
+            config('orion.use_validated')
+                ? $request->validated()
+                : $request->all(),
             $request->get('pivot', [])
         );
 

--- a/src/Concerns/HandlesStandardBatchOperations.php
+++ b/src/Concerns/HandlesStandardBatchOperations.php
@@ -46,7 +46,9 @@ trait HandlesStandardBatchOperations
 
         $this->authorize('create', $resourceModelClass);
 
-        $resources = $request->get('resources', []);
+        $resources = config('orion.use_validated')
+            ? $request->validated('resources', [])
+            : $request->get('resources', []);
         $entities = collect([]);
 
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
@@ -152,7 +154,9 @@ trait HandlesStandardBatchOperations
             $this->performUpdate(
                 $request,
                 $entity,
-                $request->input("resources.{$entity->{$this->keyName()}}")
+                config('orion.use_validated')
+                    ? $request->validated("resources.{$entity->{$this->keyName()}}")
+                    : $request->input("resources.{$entity->{$this->keyName()}}")
             );
 
             $this->beforeUpdateFresh($request, $entity);

--- a/src/Concerns/HandlesStandardOperations.php
+++ b/src/Concerns/HandlesStandardOperations.php
@@ -187,7 +187,9 @@ trait HandlesStandardOperations
         $this->performStore(
             $request,
             $entity,
-            $request->all()
+            config('orion.use_validated')
+                ? $request->validated()
+                : $request->all()
         );
 
         $beforeStoreFreshResult = $this->beforeStoreFresh($request, $entity);
@@ -432,7 +434,9 @@ trait HandlesStandardOperations
         $this->performUpdate(
             $request,
             $entity,
-            $request->all()
+            config('orion.use_validated')
+                ? $request->validated()
+                : $request->all()
         );
 
         $beforeUpdateFreshResult = $this->beforeUpdateFresh($request, $entity);


### PR DESCRIPTION
Laravel has a cool method "validated" on Request. This method returns only the validated data, filtering out any properties not defined on the validation rules. It has a similar effect to the model's fillable property but also applies to data inside arrays.

```php
$fillable = ['name', 'address'];

$rules = [
    'name' => 'string',
    'address' => 'array',
    'address.city' => 'string'
];

$data = [
    'name' => 'Ricardo',
    'address' => [
        'city' => 'Curitiba',
        'country' => 'Brazil',
    ],
    'phone' => '+5511999999999',
];

$model->fill($request->all());
// model is ['name' => ..., 'address' => ['city' => ..., 'country' => ...]]
// phone is filtered by "fillable", country is not filtered

$model->fill($request->validated());
// model is ['name' => ..., 'address' => ['city' => ...]]
// both phone and country are filtered by "validated"
```

By using the validated method we can achieve better control of the data that is being filled. Since the filtering is defined by the Request, we can have multiple request definitions (think multiple api versions) with different filling behaviors.

This PR adds a new backward compatible config (use_validated) that when set to true, uses the validated method instead of all, get or input to get resources data.

