### PR TITLE
[Fix] Consider JsonResource wrapping to generate specs

### DIFF
--- a/src/ValueObjects/Specs/Responses/Success/EntityResponse.php
+++ b/src/ValueObjects/Specs/Responses/Success/EntityResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orion\ValueObjects\Specs\Responses\Success;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Orion\ValueObjects\Specs\Response;
 
 class EntityResponse extends Response
@@ -23,14 +24,18 @@ class EntityResponse extends Response
             [
                 'content' => [
                     'application/json' => [
-                        'schema' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'data' => [
-                                    '$ref' => "#/components/schemas/{$this->resourceComponentBaseName}Resource",
+                        'schema' => JsonResource::$wrap ?
+                            [
+                                'type'       => 'object',
+                                'properties' => [
+                                    JsonResource::$wrap => [
+                                        '$ref' => "#/components/schemas/{$this->resourceComponentBaseName}Resource",
+                                    ],
                                 ],
+                            ] :
+                            [
+                                '$ref' => "#/components/schemas/{$this->resourceComponentBaseName}Resource",
                             ],
-                        ],
                     ],
                 ],
             ]


### PR DESCRIPTION
JsonResource has a property named "wrap" which defines how data should be wrapped in a response. The default value is "data" which makes the response look like this:

```php
$resource->toResponse();
/*
[
  'data' => [
    'id' => 1,
    'name' => 'Test',
    // ...
  ]
]
*/
```

The wrapping property can be changed to any value or disabled by calling `JsonResource::withoutWrapping();`. This is particularly useful, making the response return the resource directly. [Reference docs](https://laravel.com/docs/9.x/eloquent-resources#data-wrapping)

```php
$resource->toResponse();
/*
[
  'id' => 1,
  'name' => 'Test',
  // ...
]
*/
```

The current implementation of the specs generation doesn't consider the wrap configuration and wraps resources always within "data".

This PR fixes that, generating the correct specs with any wrap configuration.

The PR only considers the global wrap configuration `JsonResource::wrap`. It is important to note that this can also be set on a resource basis with `UserResource::wrap('user')`. This more specific configuration could be implemented in the future.