### PR TITLE
[Fix] Fixes batchUpdate spec

### DIFF
--- a/src/ValueObjects/Specs/Requests/Batch/BatchUpdateRequest.php
+++ b/src/ValueObjects/Specs/Requests/Batch/BatchUpdateRequest.php
@@ -29,12 +29,14 @@ class BatchUpdateRequest extends Request
                             'type' => 'object',
                             'properties' => [
                                 'resources' => [
-                                    'type' => 'array',
-                                    'items' => [
-                                        '$ref' => "#/components/schemas/{$this->resourceComponentBaseName}",
-                                    ]
-                                ]
-                            ]
+                                    'type'       => 'object',
+                                    'properties' => [
+                                        '{key}' => [
+                                            '$ref' => "#/components/schemas/{$this->resourceComponentBaseName}",
+                                        ],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],


### PR DESCRIPTION
The documentation states the following regarding batchUpdate parameters:

> The endpoint expects an object in request payload with resources **object**, where each key is a resource id and item is an object representing a resource (e.g. a post) to update.

The current implementation generates an spec with the resources param defined as an **array** of resources.

![batch-update](https://user-images.githubusercontent.com/131324/181819529-f66ec293-937a-425e-a943-41b2a22c6497.png)

This PR fixes the spec generator, making it compliant with the documentation.

![image](https://user-images.githubusercontent.com/131324/181819858-3376352c-65a6-4803-acc7-cd2ddf604774.png)

This is not the perfect description of the request, but at least the type is correct.