### PR TITLE
[Improvement] Reorder the operations during spec generation

### DIFF
--- a/src/Specs/Builders/PathsBuilder.php
+++ b/src/Specs/Builders/PathsBuilder.php
@@ -57,8 +57,20 @@ class PathsBuilder
         $resources = $this->resourcesCacheStore->getResources();
         $paths = collect([]);
 
+        $operationsOrder = [
+            'store', 'index', 'search', 'show', 'update', 'destroy', 'restore',
+            'batchStore', 'batchUpdate', 'batchDestroy', 'batchRestore',
+            'associate', 'dissociate',
+            'attach', 'detach', 'sync', 'toggle', 'updatePivot',
+        ];
+
         foreach ($resources as $resource) {
-            foreach ($resource->operations as $operationName) {
+            $operations = array_merge(
+                array_intersect($operationsOrder, $resource->operations),
+                array_diff($resource->operations, $operationsOrder)
+            );
+
+            foreach ($operations as $operationName) {
                 $route = $this->resolveRoute($resource->controller, $operationName);
 
                 if (in_array($operationName, ['index', 'search', 'store', 'show', 'update', 'destroy', 'restore'])) {
@@ -153,8 +165,8 @@ class PathsBuilder
         Route $route
     ): RelationOperationBuilder {
         $operationClassName = "Orion\\Specs\\Builders\\Operations\\Relations\\OneToMany\\" . ucfirst(
-                $operation
-            ) . 'OperationBuilder';
+            $operation
+        ) . 'OperationBuilder';
 
         return $this->relationOperationBuilderFactory->make($operationClassName, $resource, $operation, $route);
     }
@@ -172,8 +184,8 @@ class PathsBuilder
         Route $route
     ): RelationOperationBuilder {
         $operationClassName = "Orion\\Specs\\Builders\\Operations\\Relations\\ManyToMany\\" . ucfirst(
-                $operation
-            ) . 'OperationBuilder';
+            $operation
+        ) . 'OperationBuilder';
 
         return $this->relationOperationBuilderFactory->make($operationClassName, $resource, $operation, $route);
     }


### PR DESCRIPTION
The order in which the operations are described in the generated OpenApi specification is not defined and not very intuitive.

For instance, the retrieve operations are scattered among other operations. We have **`search`**, followed by `batch operations`, then back to **`index`**, then `create`, then back **`get`**.

![rewards-before](https://user-images.githubusercontent.com/131324/181841397-ffd88f67-4888-4832-b0b5-c4f5c39ac036.png)

This PR improves this by sorting the operations and grouping them together in the following order: Create, Retrieve, Update, Delete, Batch CRUD, and so on.

![batch-update2](https://user-images.githubusercontent.com/131324/181841573-24ff244c-1f8d-457a-bb27-7be544a4e213.png)
