### PR TITLE
Improves type resolution for all DBAL types

### DIFF
--- a/src/Specs/Managers/SchemaManager.php
+++ b/src/Specs/Managers/SchemaManager.php
@@ -6,11 +6,17 @@ namespace Orion\Specs\Managers;
 
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Types\Types;
 use Illuminate\Database\Eloquent\Model;
+use Orion\ValueObjects\Specs\Schema\Properties\AnySchemaProperty;
+use Orion\ValueObjects\Specs\Schema\Properties\ArraySchemaProperty;
+use Orion\ValueObjects\Specs\Schema\Properties\BinarySchemaProperty;
 use Orion\ValueObjects\Specs\Schema\Properties\BooleanSchemaProperty;
+use Orion\ValueObjects\Specs\Schema\Properties\DateSchemaProperty;
 use Orion\ValueObjects\Specs\Schema\Properties\DateTimeSchemaProperty;
 use Orion\ValueObjects\Specs\Schema\Properties\IntegerSchemaProperty;
 use Orion\ValueObjects\Specs\Schema\Properties\NumberSchemaProperty;
+use Orion\ValueObjects\Specs\Schema\Properties\ObjectSchemaProperty;
 use Orion\ValueObjects\Specs\Schema\Properties\StringSchemaProperty;
 
 class SchemaManager
@@ -46,16 +52,40 @@ class SchemaManager
         }
 
         switch ($column->getType()->getName()) {
-            case 'integer':
-            case 'bigint':
-            case 'smallint':
+            case Types::BIGINT:
+            case Types::INTEGER:
+            case Types::SMALLINT:
                 return IntegerSchemaProperty::class;
-            case 'boolean':
-                return BooleanSchemaProperty::class;
-            case 'float':
+            case Types::FLOAT:
+            case Types::DECIMAL:
                 return NumberSchemaProperty::class;
-            default:
+            case Types::BOOLEAN:
+                return BooleanSchemaProperty::class;
+            case Types::STRING:
+            case Types::TEXT:
+            case Types::ASCII_STRING:
+            case Types::GUID:
+            case Types::TIME_MUTABLE:
+            case Types::TIME_IMMUTABLE:
                 return StringSchemaProperty::class;
+            case Types::DATE_MUTABLE:
+            case Types::DATE_IMMUTABLE:
+                return DateSchemaProperty::class;
+            case Types::DATETIME_MUTABLE:
+            case Types::DATETIME_IMMUTABLE:
+                return DateTimeSchemaProperty::class;
+            case Types::JSON:
+                return AnySchemaProperty::class;
+            case Types::ARRAY:
+            case Types::SIMPLE_ARRAY:
+                return ArraySchemaProperty::class;
+            case Types::OBJECT:
+                return ObjectSchemaProperty::class;
+            case Types::BINARY:
+            case Types::BLOB:
+                return BinarySchemaProperty::class;
+            default:
+                return AnySchemaProperty::class;
         }
     }
 }

--- a/src/ValueObjects/Specs/Schema/Properties/AnySchemaProperty.php
+++ b/src/ValueObjects/Specs/Schema/Properties/AnySchemaProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orion\ValueObjects\Specs\Schema\Properties;
+
+use Orion\ValueObjects\Specs\Schema\SchemaProperty;
+
+class AnySchemaProperty extends SchemaProperty
+{
+    public $type = 'any';
+
+    public function toArray(): object
+    {
+        return (object) [];
+    }
+}

--- a/src/ValueObjects/Specs/Schema/Properties/ArraySchemaProperty.php
+++ b/src/ValueObjects/Specs/Schema/Properties/ArraySchemaProperty.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orion\ValueObjects\Specs\Schema\Properties;
+
+use Orion\ValueObjects\Specs\Schema\SchemaProperty;
+
+class ArraySchemaProperty extends SchemaProperty
+{
+    public $type = 'array';
+
+    public function toArray(): array
+    {
+        $descriptor = [
+            'type' => $this->type,
+        ];
+
+        if ($this->nullable) {
+            $descriptor['nullable'] = true;
+        }
+
+        if ($this->type == 'array') {
+            $descriptor['items'] = (object) [];
+        }
+
+        return $descriptor;
+    }
+}

--- a/src/ValueObjects/Specs/Schema/Properties/BinarySchemaProperty.php
+++ b/src/ValueObjects/Specs/Schema/Properties/BinarySchemaProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orion\ValueObjects\Specs\Schema\Properties;
+
+use Orion\ValueObjects\Specs\Schema\SchemaProperty;
+
+class BinarySchemaProperty extends SchemaProperty
+{
+    public $type = 'string';
+
+    public function toArray(): array
+    {
+        return array_merge(
+            parent::toArray(),
+            [
+                'format' => 'binary',
+            ],
+        );
+    }
+}

--- a/src/ValueObjects/Specs/Schema/Properties/DateSchemaProperty.php
+++ b/src/ValueObjects/Specs/Schema/Properties/DateSchemaProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orion\ValueObjects\Specs\Schema\Properties;
+
+use Orion\ValueObjects\Specs\Schema\SchemaProperty;
+
+class DateSchemaProperty extends SchemaProperty
+{
+    public $type = 'string';
+
+    public function toArray(): array
+    {
+        return array_merge(
+            parent::toArray(),
+            [
+                'format' => 'date',
+            ],
+        );
+    }
+}

--- a/src/ValueObjects/Specs/Schema/Properties/ObjectSchemaProperty.php
+++ b/src/ValueObjects/Specs/Schema/Properties/ObjectSchemaProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orion\ValueObjects\Specs\Schema\Properties;
+
+use Orion\ValueObjects\Specs\Schema\SchemaProperty;
+
+class ObjectSchemaProperty extends SchemaProperty
+{
+    public $type = 'object';
+
+    public function toArray(): array
+    {
+        $descriptor = [
+            'type' => $this->type,
+            'additionalProperties' => true,
+        ];
+
+        return $descriptor;
+    }
+}

--- a/src/ValueObjects/Specs/Schema/SchemaProperty.php
+++ b/src/ValueObjects/Specs/Schema/SchemaProperty.php
@@ -15,7 +15,7 @@ class SchemaProperty implements Arrayable
     /** @var bool */
     public $nullable = false;
 
-    public function toArray(): array
+    public function toArray()
     {
         $descriptor = [
             'type' => $this->type,


### PR DESCRIPTION
The DBAL library defines many default types, but only a few of those are currently implemented in Orion. Useful types like JSON, Array and Object are missing. Besides that, the current default type is "string". By adding a AnySchemaProperty and using it as default we can have better typings for our OpenApi specs.

![image](https://user-images.githubusercontent.com/131324/182644600-65238450-b21a-4e75-9ed8-3f1346f49169.png)

This PR implements type resolution for all DBAL defined types and introduces an "any" type.