### PR TITLE
Add app make to resolve Path objectValue

### DIFF
--- a/src/Specs/Builders/PathsBuilder.php
+++ b/src/Specs/Builders/PathsBuilder.php
@@ -84,7 +84,7 @@ class PathsBuilder
                 $operation = $operationBuilder->build();
 
                 if (!$path = $paths->where('path', $route->uri())->first()) {
-                    $path = new Path($route->uri());
+                    $path = app()->make(Path::class, ['path' => $route->uri()]);
 
                     $paths->put(Str::start($path->path, '/'), $path);
                 }
@@ -153,8 +153,8 @@ class PathsBuilder
         Route $route
     ): RelationOperationBuilder {
         $operationClassName = "Orion\\Specs\\Builders\\Operations\\Relations\\OneToMany\\" . ucfirst(
-                $operation
-            ) . 'OperationBuilder';
+            $operation
+        ) . 'OperationBuilder';
 
         return $this->relationOperationBuilderFactory->make($operationClassName, $resource, $operation, $route);
     }
@@ -172,8 +172,8 @@ class PathsBuilder
         Route $route
     ): RelationOperationBuilder {
         $operationClassName = "Orion\\Specs\\Builders\\Operations\\Relations\\ManyToMany\\" . ucfirst(
-                $operation
-            ) . 'OperationBuilder';
+            $operation
+        ) . 'OperationBuilder';
 
         return $this->relationOperationBuilderFactory->make($operationClassName, $resource, $operation, $route);
     }


### PR DESCRIPTION
Sometimes we need more flexibility to build paths. In this case, we need a way to extend that object value. The laravel dependencies injections can be used to give that flexibility.  I need to add more properties to mine specs. But the current implementation uses `new` to instantiate the Path. 
` $this->app->bind(SpecsPath::class, fn ($app, $params) => new Path($params['path']));`