### PR TITLE
Adding aggregates to search endpoint

### DIFF
--- a/src/Contracts/ParamsValidator.php
+++ b/src/Contracts/ParamsValidator.php
@@ -22,4 +22,6 @@ interface ParamsValidator
     public function validateSort(Request $request): void;
 
     public function validateSearch(Request $request): void;
+
+    public function validateAggregators(Request $request): void;
 }

--- a/src/Contracts/QueryBuilder.php
+++ b/src/Contracts/QueryBuilder.php
@@ -57,4 +57,11 @@ interface QueryBuilder
      * @return bool
      */
     public function applySoftDeletesToQuery($query, Request $request): bool;
+
+    /**
+     * @param Builder|Relation $query
+     * @param Request $request
+     * @return bool
+     */
+    public function applyAggregatesToQuery($query, Request $request, array $aggregateDescriptors = []): void;
 }

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -152,9 +152,9 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
         Validator::make(
             $request->all(),
             [
-                'aggregates' => ['sometimes', 'array'],
+                'aggregates' => ['sometimes', 'array:count,min,max,avg,sum,exists'],
                 'aggregates.count' => ['sometimes', 'array'],
-                'aggregates.count.*.field' => [
+                'aggregates.*.*.field' => [
                     'required',
                     'regex:/^[\w.\_\-\>]+$/',
                     new WhitelistedField($this->aggregatableBy),

--- a/src/Drivers/Standard/ParamsValidator.php
+++ b/src/Drivers/Standard/ParamsValidator.php
@@ -24,13 +24,19 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
     private $sortableBy;
 
     /**
+     * @var string[]
+     */
+    private $aggregatableBy;
+
+    /**
      * @inheritDoc
      */
-    public function __construct(array $exposedScopes = [], array $filterableBy = [], array $sortableBy = [])
+    public function __construct(array $exposedScopes = [], array $filterableBy = [], array $sortableBy = [], array $aggregatableBy = [])
     {
         $this->exposedScopes = $exposedScopes;
         $this->filterableBy = $filterableBy;
         $this->sortableBy = $sortableBy;
+        $this->aggregatableBy = $aggregatableBy;
     }
 
     public function validateScopes(Request $request): void
@@ -137,6 +143,22 @@ class ParamsValidator implements \Orion\Contracts\ParamsValidator
                 'search' => ['sometimes', 'array'],
                 'search.value' => ['string', 'nullable'],
                 'search.case_sensitive' => ['bool'],
+            ]
+        )->validate();
+    }
+
+    public function validateAggregators(Request $request): void
+    {
+        Validator::make(
+            $request->all(),
+            [
+                'aggregates' => ['sometimes', 'array'],
+                'aggregates.count' => ['sometimes', 'array'],
+                'aggregates.count.*.field' => [
+                    'required',
+                    'regex:/^[\w.\_\-\>]+$/',
+                    new WhitelistedField($this->aggregatableBy),
+                ],
             ]
         )->validate();
     }

--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -112,6 +112,7 @@ abstract class BaseController extends \Illuminate\Routing\Controller
                 'exposedScopes' => $this->exposedScopes(),
                 'filterableBy' => $this->filterableBy(),
                 'sortableBy' => $this->sortableBy(),
+                'aggregatableBy' => $this->aggregatableBy()
             ]
         );
         $this->relationsResolver = App::makeWith(
@@ -219,6 +220,16 @@ abstract class BaseController extends \Illuminate\Routing\Controller
      * @return array
      */
     public function alwaysIncludes(): array
+    {
+        return [];
+    }
+
+    /**
+     * The relations that are allowed to be aggregated with a resource.
+     *
+     * @return array
+     */
+    public function aggregatableBy(): array
     {
         return [];
     }


### PR DESCRIPTION
This is a first proposition to allow aggregates in laravel Orion. Closes #127

The post params:

```json
{
  "aggregates": {
    { "count":
      {"field": "posts"}
    }
  }
}
```

This is adding a "field_count" to the result as Laravel would do with "withCount".

```json
{
    "data": [
        {
            "id": 1,
            "name": "Leslie Zieme",
            "email": "nienow.tabitha@example.org",
            "email_verified_at": "2022-10-06T18:55:35.000000Z",
            "created_at": "2022-10-06T18:55:35.000000Z",
            "updated_at": "2022-10-06T18:55:35.000000Z",
            "posts_count": 3
        },
  ]
}
```



I think this is a great approach but we might want to switch one level of "aggregating" and add a type such as:

```json
{
  "aggregates": {
    {"field": "posts", "type": "count"}
  }
}
```

I'm waiting for your feedback !