### PR TITLE
Only add tags that are missing from config

### DIFF
--- a/src/Specs/Builders/TagsBuilder.php
+++ b/src/Specs/Builders/TagsBuilder.php
@@ -24,7 +24,7 @@ class TagsBuilder
         $tags = collect(config('orion.specs.tags'));
 
         foreach ($resources as $resource) {
-            $tags[] = [
+            if (!$tags->contains('name', $resource->tag)) $tags[] = [
                 'name'        => $resource->tag,
                 'description' => "API documentation for {$resource->tag}",
             ];


### PR DESCRIPTION
By this, I hope to be able to use config to describe the tags for my API docs page renderer, since it uses the last instance of the defined tag by default (which always ends up being this dummy description).

Also, by all means, if I'm out of place here, show me what I should do instead! 😅 I hope I'm not causing a problem with this.