### PR TITLE
remove filters entry for relation

### DIFF
--- a/src/Specs/Builders/Partials/RequestBody/Search/IncludesBuilder.php
+++ b/src/Specs/Builders/Partials/RequestBody/Search/IncludesBuilder.php
@@ -23,12 +23,8 @@ class IncludesBuilder extends SearchPartialBuilder
                         'type' => 'string',
                         'enum' => $this->controller->includes(),
                     ],
-                    'filters' => [
-                        'type' => 'object',
-                        'properties' => app()->makeWith(FiltersBuilder::class, ['controller' => get_class($this->controller)])->build(),
-                    ],
-                ]
-            ]
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
With the `filters` entry the Specs are broken

![image](https://github.com/tailflow/laravel-orion/assets/138459207/2980d1e5-0081-4b66-a5f1-2b1ca8f8aef4)

I think the filter is wrong here. We can't filter on the fields of the parent entity in the relation.