### PR TITLE
Add routing method to remove search route

### DIFF
--- a/src/Http/Routing/PendingResourceRegistration.php
+++ b/src/Http/Routing/PendingResourceRegistration.php
@@ -63,4 +63,20 @@ class PendingResourceRegistration extends \Illuminate\Routing\PendingResourceReg
 
         return $this;
     }
+
+    /**
+     * Disables the search operation on the resource.
+     *
+     * @return $this
+     */
+    public function withoutSearch(): PendingResourceRegistration
+    {
+        $except = Arr::get($this->options, 'except');
+
+        $except = array_merge($except, ['search']);
+
+        $this->except($except);
+
+        return $this;
+    }
 }

--- a/tests/Unit/OrionTest.php
+++ b/tests/Unit/OrionTest.php
@@ -689,4 +689,49 @@ class OrionTest extends TestCase
         $this->assertRouteRegistered('api.projects.users.batchDestroy', ['DELETE'], 'api/projects/{project}/users/batch', DummyController::class.'@batchDestroy');
         $this->assertRouteRegistered('api.projects.users.batchRestore', ['POST'], 'api/projects/{project}/users/batch/restore', DummyController::class.'@batchRestore');
     }
+
+    /** @test */
+    public function registering_resource_without_batch_removes_routes(): void
+    {
+        Route::group(
+            ['as' => 'api.', 'prefix' => 'api'],
+            function () {
+                Orion::resource('projects', DummyController::class)->withoutBatch();
+            }
+        );
+
+        $this->assertRouteRegistered('api.projects.search', ['POST'], 'api/projects/search', DummyController::class.'@search');
+        $this->assertRouteRegistered('api.projects.index', ['GET', 'HEAD'], 'api/projects', DummyController::class.'@index');
+        $this->assertRouteRegistered('api.projects.store', ['POST'], 'api/projects', DummyController::class.'@store');
+        $this->assertRouteRegistered('api.projects.show', ['GET', 'HEAD'], 'api/projects/{project}', DummyController::class.'@show');
+        $this->assertRouteRegistered('api.projects.update', ['PUT', 'PATCH'], 'api/projects/{project}', DummyController::class.'@update');
+        $this->assertRouteRegistered('api.projects.destroy', ['DELETE'], 'api/projects/{project}', DummyController::class.'@destroy');
+
+        $this->assertRouteNotRegistered('api.projects.batchStore');
+        $this->assertRouteNotRegistered('api.projects.batchUpdate');
+        $this->assertRouteNotRegistered('api.projects.batchDestroy');
+    }
+
+    /** @test */
+    public function registering_resource_without_search_removes_routes(): void
+    {
+        Route::group(
+            ['as' => 'api.', 'prefix' => 'api'],
+            function () {
+                Orion::resource('projects', DummyController::class)->withoutSearch();
+            }
+        );
+
+        $this->assertRouteNotRegistered('api.projects.search');
+
+        $this->assertRouteRegistered('api.projects.index', ['GET', 'HEAD'], 'api/projects', DummyController::class.'@index');
+        $this->assertRouteRegistered('api.projects.store', ['POST'], 'api/projects', DummyController::class.'@store');
+        $this->assertRouteRegistered('api.projects.show', ['GET', 'HEAD'], 'api/projects/{project}', DummyController::class.'@show');
+        $this->assertRouteRegistered('api.projects.update', ['PUT', 'PATCH'], 'api/projects/{project}', DummyController::class.'@update');
+        $this->assertRouteRegistered('api.projects.destroy', ['DELETE'], 'api/projects/{project}', DummyController::class.'@destroy');
+
+        $this->assertRouteRegistered('api.projects.batchStore', ['POST'], 'api/projects/batch', DummyController::class.'@batchStore');
+        $this->assertRouteRegistered('api.projects.batchUpdate', ['PATCH'], 'api/projects/batch', DummyController::class.'@batchUpdate');
+        $this->assertRouteRegistered('api.projects.batchDestroy', ['DELETE'], 'api/projects/batch', DummyController::class.'@batchDestroy');
+    }
 }


### PR DESCRIPTION
This PR introduces a new method called `withoutSearch()` which is similar to the `withoutBatch()` method and removes the `search` endpoint from the resource declaration.
I know its pretty easy to do `->except('search')`, but this overwrites the default `except` values, so you have to do `->except(['search', 'restore'])` at the least.
I added tests to cover this and I didn't find any for the `withoutBatch()`, so I included them as well.
Let me know if I should do anything else in this PR. Thanks