### PR TITLE
feat: add select fields to query params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "illuminate/http": ">=5.7",
         "illuminate/pagination": ">=5.7",
         "illuminate/support": ">=5.7",
+        "laravel/legacy-factories": "^1.3",
         "symfony/yaml": "^5.3|^6.0"
     },
     "require-dev": {

--- a/tests/Feature/StandardIndexOperationsTest.php
+++ b/tests/Feature/StandardIndexOperationsTest.php
@@ -250,4 +250,21 @@ class StandardIndexOperationsTest extends TestCase
             $this->makePaginator($posts, 'posts')
         );
     }
+
+    /** @test */
+    public function getting_a_list_of_resources_with_fields(): void
+    {
+        $user = factory(User::class)->create();
+        factory(Post::class)->times(5)->create(['user_id' => $user->id]);
+
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->get('/api/posts?fields[posts]=title,user_id&fields[user]=id,name&include=user');
+        $expectedResult = Post::with('user:id,name')->select('title', 'user_id')->get()->toArray();
+        $this->assertResourcesPaginated(
+            $response,
+            $this->makePaginator($expectedResult, 'posts')
+        );
+    }
 }


### PR DESCRIPTION
## What ? 
- This feature allows us to choose fields while fetching an index using `fields` query parameter.

## How to use ?
We can simply add fields array to query params. Each index of the fields array represents a relation name. For example, 
`/api/posts?fields[posts]=title,user_id&fields[user]=id,name&include=user `

### /!\ Good to know: 
Make sure you add the relation to the `include` query params, and the keys to the select fields.

## What's next ?
If this PR got accepted and merged, I will create a PR for the TS repo 

Happy coding