### PR TITLE
Prevent query builder from overwriting scopes

### DIFF
--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -72,6 +72,9 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         $actionMethod = $request->route()->getActionMethod();
 
         if (!$this->intermediateMode) {
+            $this->applyIncludesToQuery($query, $request);
+            $this->applyAggregatesToQuery($query, $request);
+
             if (in_array($actionMethod, ['index', 'search', 'show'])) {
                 if ($actionMethod === 'search') {
                     $this->applyScopesToQuery($query, $request);
@@ -81,9 +84,6 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
                 }
                 $this->applySoftDeletesToQuery($query, $request);
             }
-
-            $this->applyIncludesToQuery($query, $request);
-            $this->applyAggregatesToQuery($query, $request);
         }
 
         return $query;

--- a/tests/Fixtures/app/Models/Post.php
+++ b/tests/Fixtures/app/Models/Post.php
@@ -94,9 +94,26 @@ class Post extends Model
         return $query->where('publish_at', '<', Carbon::now());
     }
 
+    /**
+     * @param Builder $query
+     * @param string $dateTime
+     * @return Builder|\Illuminate\Database\Query\Builder
+     */
     public function scopePublishedAt(Builder $query, string $dateTime)
     {
         return $query->where('publish_at', $dateTime);
+    }
+
+    /**
+     * @param Builder $query
+     * @param string $direction
+     * @return Builder|\Illuminate\Database\Query\Builder
+     */
+    public function scopeOrderComments(Builder $query, string $direction = 'asc')
+    {
+        return $query->with(['comments' => function (MorphMany $query) use ($direction) {
+            $query->orderBy('created_at', $direction);
+        }]);
     }
 
     /**


### PR DESCRIPTION
This PR is directly related to #256. Due to `applyIncludesToQuery` being after any of the filtering/scoping for a search endpoint, if your scope eager loads any of the same relationships as in the `include` parameter, the scope is overwritten and thus no longer applies. This PR simply reorders the query modifiers so that your explicit scope declarations will always take precedence.

Endpoint: /api/tasks/search?include=users
Scope:
```
public function scopeSomething(Builder $query): void
{
    $query->with(['users' => fn($query) => do something ]);
}
```

Scope would not be applied since the include is also eager loading the relationship and would take precedence.