### PR TITLE
feat: add the ability to create API routes with multiple route parameters

### DIFF
--- a/src/Concerns/HandlesRelationManyToManyOperations.php
+++ b/src/Concerns/HandlesRelationManyToManyOperations.php
@@ -17,11 +17,13 @@ trait HandlesRelationManyToManyOperations
      * Attach resource to the relation in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed>$args
      * @return JsonResponse
      */
-    public function attach(Request $request, $parentKey)
+    public function attach(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->attachWithTransaction($request, $parentKey);
@@ -237,11 +239,13 @@ trait HandlesRelationManyToManyOperations
      * Detach resource to the relation in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return JsonResponse
      */
-    public function detach(Request $request, $parentKey)
+    public function detach(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->detachWithTransaction($request, $parentKey);
@@ -360,11 +364,13 @@ trait HandlesRelationManyToManyOperations
      * Sync relation resources in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return JsonResponse
      */
-    public function sync(Request $request, $parentKey)
+    public function sync(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->syncWithTransaction($request, $parentKey);
@@ -486,11 +492,13 @@ trait HandlesRelationManyToManyOperations
      * Toggle relation resources in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return JsonResponse
      */
-    public function toggle(Request $request, $parentKey)
+    public function toggle(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->toggleWithTransaction($request, $parentKey);
@@ -603,12 +611,14 @@ trait HandlesRelationManyToManyOperations
      * Update relation resource pivot in a transaction-safe wqy.
      *
      * @param Request $request
-     * @param int|string $parentKey
-     * @param int|string $relatedKey
+     * @param array<int, mixed> $args
      * @return JsonResponse
      */
-    public function updatePivot(Request $request, $parentKey, $relatedKey)
+    public function updatePivot(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+        $relatedKey = $this->keyResolver->resolveRelationOperationRelatedKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->updatePivotWithTransaction($request, $parentKey, $relatedKey);

--- a/src/Concerns/HandlesRelationOneToManyOperations.php
+++ b/src/Concerns/HandlesRelationOneToManyOperations.php
@@ -14,11 +14,13 @@ trait HandlesRelationOneToManyOperations
      * Associates resource with another resource in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return Resource
      */
-    public function associate(Request $request, $parentKey)
+    public function associate(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->associateWithTransaction($request, $parentKey);
@@ -164,12 +166,14 @@ trait HandlesRelationOneToManyOperations
      * Disassociates resource from another resource in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
-     * @param int|string $relatedKey
+     * @param array<int, mixed> $args
      * @return Resource
      */
-    public function dissociate(Request $request, $parentKey, $relatedKey)
+    public function dissociate(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+        $relatedKey = $this->keyResolver->resolveRelationOperationRelatedKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->dissociateWithTransaction($request, $parentKey, $relatedKey);

--- a/src/Concerns/HandlesRelationStandardBatchOperations.php
+++ b/src/Concerns/HandlesRelationStandardBatchOperations.php
@@ -17,11 +17,13 @@ trait HandlesRelationStandardBatchOperations
      * Create a batch of new relation resources in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return CollectionResource
      */
-    public function batchStore(Request $request, $parentKey)
+    public function batchStore(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->batchStoreWithTransaction($request, $parentKey);
@@ -161,11 +163,13 @@ trait HandlesRelationStandardBatchOperations
      * Updates a batch of relation resources in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return CollectionResource
      */
-    public function batchUpdate(Request $request, $parentKey)
+    public function batchUpdate(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->batchUpdateWithTransaction($request, $parentKey);
@@ -355,12 +359,14 @@ trait HandlesRelationStandardBatchOperations
      * Deletes a batch of relation resources in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return CollectionResource
      * @throws Exception
      */
-    public function batchDestroy(Request $request, $parentKey)
+    public function batchDestroy(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->batchDestroyWithTransaction($request, $parentKey);
@@ -527,12 +533,14 @@ trait HandlesRelationStandardBatchOperations
      * Restores a batch of relation resources in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return CollectionResource
      * @throws Exception
      */
-    public function batchRestore(Request $request, $parentKey)
+    public function batchRestore(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->batchRestoreWithTransaction($request, $parentKey);

--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -257,11 +257,13 @@ trait HandlesRelationStandardOperations
      * Create new relation resource.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return Resource
      */
-    public function store(Request $request, $parentKey)
+    public function store(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->storeWithTransaction($request, $parentKey);

--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -27,12 +27,14 @@ trait HandlesRelationStandardOperations
      * Fetch the list of relation resources.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @return CollectionResource
      */
-    public function index(Request $request, $parentKey)
+    public function index(Request $request, ...$args)
     {
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
+
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
 
         $parentQuery = $this->buildIndexParentFetchQuery($request, $parentKey);
         $parentEntity = $this->runIndexParentFetchQuery($request, $parentQuery, $parentKey);
@@ -484,12 +486,14 @@ trait HandlesRelationStandardOperations
      * Fetch a relation resource.
      *
      * @param Request $request
-     * @param int|string $parentKey
-     * @param int|string|null $relatedKey
+     * @param array<int, mixed> $args
      * @return Resource
      */
-    public function show(Request $request, $parentKey, $relatedKey = null)
+    public function show(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+        $relatedKey = $this->keyResolver->resolveRelationOperationRelatedKey($request, $args);
+
         $parentQuery = $this->buildShowParentFetchQuery($request, $parentKey);
         $parentEntity = $this->runShowParentFetchQuery($request, $parentQuery, $parentKey);
 
@@ -672,12 +676,15 @@ trait HandlesRelationStandardOperations
      * Update a relation resource in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @param int|string|null $relatedKey
      * @return Resource
      */
-    public function update(Request $request, $parentKey, $relatedKey = null)
+    public function update(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+        $relatedKey = $this->keyResolver->resolveRelationOperationRelatedKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->updateWithTransaction($request, $parentKey, $relatedKey);
@@ -889,13 +896,16 @@ trait HandlesRelationStandardOperations
      * Delete a relation resource.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @param int|string|null $relatedKey
      * @return Resource
      * @throws Exception
      */
-    public function destroy(Request $request, $parentKey, $relatedKey = null)
+    public function destroy(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+        $relatedKey = $this->keyResolver->resolveRelationOperationRelatedKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->destroyWithTransaction($request, $parentKey, $relatedKey);
@@ -1079,12 +1089,15 @@ trait HandlesRelationStandardOperations
      * Restores a previously deleted relation resource in a transaction-save way.
      *
      * @param Request $request
-     * @param int|string $parentKey
+     * @param array<int, mixed> $args
      * @param int|string|null $relatedKey
      * @return Resource
      */
-    public function restore(Request $request, $parentKey, $relatedKey = null)
+    public function restore(Request $request, ...$args)
     {
+        $parentKey = $this->keyResolver->resolveRelationOperationParentKey($request, $args);
+        $relatedKey = $this->keyResolver->resolveRelationOperationRelatedKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->restoreWithTransaction($request, $parentKey, $relatedKey);

--- a/src/Concerns/HandlesStandardOperations.php
+++ b/src/Concerns/HandlesStandardOperations.php
@@ -329,7 +329,7 @@ trait HandlesStandardOperations
      * Fetches resource.
      *
      * @param Request $request
-     * @param int|string $key
+     * @param array<int, mixed> $args
      * @return Resource
      * @throws AuthorizationException
      * @throws BindingResolutionException
@@ -440,11 +440,13 @@ trait HandlesStandardOperations
      * Update a resource in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $key
+     * @param array<int, mixed> $args
      * @return Resource
      */
-    public function update(Request $request, $key)
+    public function update(Request $request, ...$args)
     {
+        $key = $this->keyResolver->resolveStandardOperationKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->updateWithTransaction($request, $key);
@@ -604,12 +606,14 @@ trait HandlesStandardOperations
      * Deletes a resource.
      *
      * @param Request $request
-     * @param int|string $key
+     * @param array<int, mixed> $args
      * @return Resource
      * @throws Exception
      */
-    public function destroy(Request $request, $key)
+    public function destroy(Request $request, ...$args)
     {
+        $key = $this->keyResolver->resolveStandardOperationKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->destroyWithTransaction($request, $key);
@@ -769,12 +773,14 @@ trait HandlesStandardOperations
      * Restore previously deleted resource in a transaction-safe way.
      *
      * @param Request $request
-     * @param int|string $key
+     * @param array<int, mixed> $args
      * @return Resource
      * @throws Exception
      */
-    public function restore(Request $request, $key)
+    public function restore(Request $request, ...$args)
     {
+        $key = $this->keyResolver->resolveStandardOperationKey($request, $args);
+
         try {
             $this->startTransaction();
             $result = $this->restoreWithTransaction($request, $key);

--- a/src/Concerns/HandlesStandardOperations.php
+++ b/src/Concerns/HandlesStandardOperations.php
@@ -334,11 +334,13 @@ trait HandlesStandardOperations
      * @throws AuthorizationException
      * @throws BindingResolutionException
      */
-    public function show(Request $request, $key)
+    public function show(Request $request, ...$args)
     {
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
 
         $query = $this->buildShowFetchQuery($request, $requestedRelations);
+
+        $key = $this->keyResolver->resolveStandardOperationKey($request, $args);
 
         $beforeHookResult = $this->beforeShow($request, $key);
         if ($this->hookResponds($beforeHookResult)) {

--- a/src/Contracts/KeyResolver.php
+++ b/src/Contracts/KeyResolver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Orion\Contracts;
+
+use Illuminate\Http\Request;
+
+interface KeyResolver
+{
+    public function resolveStandardOperationKey(Request $request, array $args);
+
+    public function resolveRelationOperationParentKey(Request $request, array $args);
+
+    public function resolveRelationOperationRelatedKey(Request $request, array $args);
+}

--- a/src/Drivers/Standard/KeyResolver.php
+++ b/src/Drivers/Standard/KeyResolver.php
@@ -18,6 +18,6 @@ class KeyResolver implements \Orion\Contracts\KeyResolver
 
     public function resolveRelationOperationRelatedKey(Request $request, array $args)
     {
-        return $args[1];
+        return $args[1] ?? null;
     }
 }

--- a/src/Drivers/Standard/KeyResolver.php
+++ b/src/Drivers/Standard/KeyResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Orion\Drivers\Standard;
+
+use Illuminate\Http\Request;
+
+class KeyResolver implements \Orion\Contracts\KeyResolver
+{
+    public function resolveStandardOperationKey(Request $request, array $args)
+    {
+        return $args[0];
+    }
+
+    public function resolveRelationOperationParentKey(Request $request, array $args)
+    {
+        return $args[0];
+    }
+
+    public function resolveRelationOperationRelatedKey(Request $request, array $args)
+    {
+        return $args[1];
+    }
+}

--- a/src/Http/Controllers/BaseController.php
+++ b/src/Http/Controllers/BaseController.php
@@ -20,6 +20,7 @@ use Orion\Concerns\InteractsWithBatchResources;
 use Orion\Concerns\InteractsWithHooks;
 use Orion\Concerns\InteractsWithSoftDeletes;
 use Orion\Contracts\ComponentsResolver;
+use Orion\Contracts\KeyResolver;
 use Orion\Contracts\Paginator;
 use Orion\Contracts\ParamsValidator;
 use Orion\Contracts\QueryBuilder;
@@ -79,6 +80,11 @@ abstract class BaseController extends \Illuminate\Routing\Controller
      * @var RelationsResolver $relationsResolver
      */
     protected $relationsResolver;
+
+    /**
+     * @var KeyResolver $keyResolver
+     */
+    protected $keyResolver;
 
     /**
      * @var Paginator $paginator
@@ -152,6 +158,7 @@ abstract class BaseController extends \Illuminate\Routing\Controller
                 'intermediateMode' => $this instanceof RelationController,
             ]
         );
+        $this->keyResolver = App::make(KeyResolver::class);
 
         $this->resolveComponents();
         $this->bindComponents();
@@ -480,6 +487,25 @@ abstract class BaseController extends \Illuminate\Routing\Controller
     public function setRelationsResolver(RelationsResolver $relationsResolver): self
     {
         $this->relationsResolver = $relationsResolver;
+
+        return $this;
+    }
+
+    /**
+     * @return KeyResolver
+     */
+    public function getKeyResolver(): KeyResolver
+    {
+        return $this->keyResolver;
+    }
+
+    /**
+     * @param KeyResolver $keyResolver
+     * @return $this
+     */
+    public function setKeyResolver(KeyResolver $keyResolver): self
+    {
+        $this->keyResolver = $keyResolver;
 
         return $this;
     }

--- a/src/OrionServiceProvider.php
+++ b/src/OrionServiceProvider.php
@@ -5,6 +5,7 @@ namespace Orion;
 use Illuminate\Support\ServiceProvider;
 use Orion\Commands\BuildSpecsCommand;
 use Orion\Contracts\ComponentsResolver;
+use Orion\Contracts\KeyResolver;
 use Orion\Contracts\Paginator;
 use Orion\Contracts\ParamsValidator;
 use Orion\Contracts\QueryBuilder;
@@ -29,6 +30,7 @@ class OrionServiceProvider extends ServiceProvider
         $this->app->bind(Paginator::class, Drivers\Standard\Paginator::class);
         $this->app->bind(SearchBuilder::class, Drivers\Standard\SearchBuilder::class);
         $this->app->bind(ComponentsResolver::class, Drivers\Standard\ComponentsResolver::class);
+        $this->app->bind(KeyResolver::class, Drivers\Standard\KeyResolver::class);
 
         $this->app->singleton(ResourcesCacheStore::class);
     }
@@ -41,7 +43,6 @@ class OrionServiceProvider extends ServiceProvider
     public function boot()
     {
         app('router')->pushMiddlewareToGroup('api', EnforceExpectsJson::class);
-
 
         $this->publishes(
             [

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardDeleteOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardDeleteOperationsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
+use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Category;
 use Orion\Tests\Fixtures\App\Models\Post;
@@ -157,5 +158,33 @@ class BelongsToRelationStandardDeleteOperationsTest extends TestCase
         $response = $this->delete("/api/posts/{$post->id}/user?include=posts");
 
         $this->assertResourceDeleted($response, $user, ['posts' => [$post->toArray()]]);
+    }
+
+    /** @test */
+    public function deleting_a_single_relation_resource_with_multiple_route_parameters(): void
+    {
+        $this->useKeyResolver(TwoRouteParameterKeyResolver::class);
+
+        $category = factory(Category::class)->create();
+        $post = factory(Post::class)->create(['category_id' => $category->id]);
+
+        Gate::policy(Category::class, GreenPolicy::class);
+
+        $response = $this->delete("/api/v1/posts/{$post->id}/category");
+
+        $this->assertResourceTrashed($response, $category);
+    }
+
+    /** @test */
+    public function deleting_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
+    {
+        $category = factory(Category::class)->create();
+        $post = factory(Post::class)->create(['category_id' => $category->id]);
+
+        Gate::policy(Category::class, GreenPolicy::class);
+
+        $response = $this->delete("/api/v1/posts/{$post->id}/category");
+
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardDeleteOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardDeleteOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature\Relations\BelongsTo;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
@@ -178,6 +180,10 @@ class BelongsToRelationStandardDeleteOperationsTest extends TestCase
     /** @test */
     public function deleting_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $category = factory(Category::class)->create();
         $post = factory(Post::class)->create(['category_id' => $category->id]);
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardDeleteOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardDeleteOperationsTest.php
@@ -181,6 +181,7 @@ class BelongsToRelationStandardDeleteOperationsTest extends TestCase
     public function deleting_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardRestoreOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardRestoreOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature\Relations\BelongsTo;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
@@ -112,6 +114,10 @@ class BelongsToRelationStandardRestoreOperationsTest extends TestCase
     /** @test */
     public function restoring_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $trashedCategory = factory(Category::class)->state('trashed')->create();
         $post = factory(Post::class)->create(['category_id' => $trashedCategory->id]);
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardRestoreOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardRestoreOperationsTest.php
@@ -3,9 +3,8 @@
 namespace Orion\Tests\Feature\Relations\BelongsTo;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
+use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Category;
 use Orion\Tests\Fixtures\App\Models\Post;
@@ -93,5 +92,33 @@ class BelongsToRelationStandardRestoreOperationsTest extends TestCase
         $response = $this->post("/api/posts/{$post->id}/category/{$trashedCategory->id}/restore?include=posts");
 
         $this->assertResourceRestored($response, $trashedCategory, ['posts' => $trashedCategory->posts->toArray()]);
+    }
+
+    /** @test */
+    public function restoring_a_single_relation_resource_with_multiple_route_parameters(): void
+    {
+        $this->useKeyResolver(TwoRouteParameterKeyResolver::class);
+
+        $trashedCategory = factory(Category::class)->state('trashed')->create();
+        $post = factory(Post::class)->create(['category_id' => $trashedCategory->id]);
+
+        Gate::policy(Category::class, GreenPolicy::class);
+
+        $response = $this->post("/api/v1/posts/{$post->id}/category/{$trashedCategory->id}/restore");
+
+        $this->assertResourceRestored($response, $trashedCategory);
+    }
+
+    /** @test */
+    public function restoring_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
+    {
+        $trashedCategory = factory(Category::class)->state('trashed')->create();
+        $post = factory(Post::class)->create(['category_id' => $trashedCategory->id]);
+
+        Gate::policy(Category::class, GreenPolicy::class);
+
+        $response = $this->post("/api/v1/posts/{$post->id}/category/{$trashedCategory->id}/restore");
+
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardRestoreOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardRestoreOperationsTest.php
@@ -115,6 +115,7 @@ class BelongsToRelationStandardRestoreOperationsTest extends TestCase
     public function restoring_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardShowOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardShowOperationsTest.php
@@ -4,6 +4,7 @@ namespace Orion\Tests\Feature\Relations\BelongsTo;
 
 use Illuminate\Support\Facades\Gate;
 use Orion\Tests\Feature\TestCase;
+use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Category;
 use Orion\Tests\Fixtures\App\Models\Post;
@@ -65,7 +66,6 @@ class BelongsToRelationStandardShowOperationsTest extends TestCase
         $this->assertResourceShown($response, $trashedCategory);
     }
 
-
     /** @test */
     public function getting_a_single_transformed_relation_resource(): void
     {
@@ -109,5 +109,33 @@ class BelongsToRelationStandardShowOperationsTest extends TestCase
         $response = $this->get("/api/posts/{$post->id}/user?with_count=posts");
 
         $this->assertResourceShown($response, $user->fresh()->loadCount('posts')->toArray());
+    }
+
+    /** @test */
+    public function getting_a_single_relation_resource_with_multiple_route_parameters(): void
+    {
+        $this->useKeyResolver(TwoRouteParameterKeyResolver::class);
+
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create(['user_id' => $user->id]);
+
+        Gate::policy(User::class, GreenPolicy::class);
+
+        $response = $this->get("/api/v1/posts/{$post->id}/user");
+
+        $this->assertResourceShown($response, $user);
+    }
+
+    /** @test */
+    public function getting_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
+    {
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create(['user_id' => $user->id]);
+
+        Gate::policy(User::class, GreenPolicy::class);
+
+        $response = $this->get("/api/v1/posts/{$post->id}/user");
+
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardShowOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardShowOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature\Relations\BelongsTo;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
@@ -129,6 +131,10 @@ class BelongsToRelationStandardShowOperationsTest extends TestCase
     /** @test */
     public function getting_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $user = factory(User::class)->create();
         $post = factory(Post::class)->create(['user_id' => $user->id]);
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardShowOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardShowOperationsTest.php
@@ -132,6 +132,7 @@ class BelongsToRelationStandardShowOperationsTest extends TestCase
     public function getting_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardUpdateOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardUpdateOperationsTest.php
@@ -155,6 +155,7 @@ class BelongsToRelationStandardUpdateOperationsTest extends TestCase
     public function updating_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardUpdateOperationsTest.php
+++ b/tests/Feature/Relations/BelongsTo/BelongsToRelationStandardUpdateOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature\Relations\BelongsTo;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
@@ -152,6 +154,10 @@ class BelongsToRelationStandardUpdateOperationsTest extends TestCase
     /** @test */
     public function updating_a_single_relation_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $user = factory(User::class)->create();
         $post = factory(Post::class)->create(['user_id' => $user->id]);
         $payload = ['name' => 'test user updated'];

--- a/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardDeleteOperationsTest.php
+++ b/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardDeleteOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\BelongsToMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Notification;

--- a/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardIndexOperationsTest.php
+++ b/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardIndexOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\BelongsToMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleCollectionResource;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;

--- a/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardRestoreOperationsTest.php
+++ b/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardRestoreOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\BelongsToMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Notification;

--- a/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardShowOperationsTest.php
+++ b/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardShowOperationsTest.php
@@ -95,7 +95,6 @@ class BelongsToManyRelationStandardShowOperationsTest extends TestCase
         $this->assertResourceShown($response, $user->notifications()->withTrashed()->first()->toArray());
     }
 
-
     /** @test */
     public function getting_a_single_transformed_relation_resource(): void
     {

--- a/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardStoreOperationsTest.php
+++ b/tests/Feature/Relations/BelongsToMany/BelongsToManyRelationStandardStoreOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\BelongsToMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Requests\RoleRequest;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;

--- a/tests/Feature/Relations/HasMany/HasManyRelationStandardDeleteOperationsTest.php
+++ b/tests/Feature/Relations/HasMany/HasManyRelationStandardDeleteOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\AccessKey;

--- a/tests/Feature/Relations/HasMany/HasManyRelationStandardIndexOperationsTest.php
+++ b/tests/Feature/Relations/HasMany/HasManyRelationStandardIndexOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleCollectionResource;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;

--- a/tests/Feature/Relations/HasMany/HasManyRelationStandardRestoreOperationsTest.php
+++ b/tests/Feature/Relations/HasMany/HasManyRelationStandardRestoreOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\AccessKey;

--- a/tests/Feature/Relations/HasMany/HasManyRelationStandardShowOperationsTest.php
+++ b/tests/Feature/Relations/HasMany/HasManyRelationStandardShowOperationsTest.php
@@ -81,7 +81,6 @@ class HasManyRelationStandardShowOperationsTest extends TestCase
         $this->assertResourceShown($response, $trashedPost);
     }
 
-
     /** @test */
     public function getting_a_single_transformed_relation_resource(): void
     {

--- a/tests/Feature/Relations/HasMany/HasManyRelationStandardStoreOperationsTest.php
+++ b/tests/Feature/Relations/HasMany/HasManyRelationStandardStoreOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Requests\TeamRequest;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;

--- a/tests/Feature/Relations/HasMany/HasManyRelationStandardUpdateOperationsTest.php
+++ b/tests/Feature/Relations/HasMany/HasManyRelationStandardUpdateOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasMany;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Requests\TeamRequest;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;

--- a/tests/Feature/Relations/HasOne/HasOneRelationStandardDeleteOperationsTest.php
+++ b/tests/Feature/Relations/HasOne/HasOneRelationStandardDeleteOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasOne;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Post;

--- a/tests/Feature/Relations/HasOne/HasOneRelationStandardRestoreOperationsTest.php
+++ b/tests/Feature/Relations/HasOne/HasOneRelationStandardRestoreOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasOne;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Post;

--- a/tests/Feature/Relations/HasOne/HasOneRelationStandardShowOperationsTest.php
+++ b/tests/Feature/Relations/HasOne/HasOneRelationStandardShowOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasOne;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Post;
@@ -66,7 +64,6 @@ class HasOneRelationStandardShowOperationsTest extends TestCase
 
         $this->assertResourceShown($response, $trashedPostMeta);
     }
-
 
     /** @test */
     public function getting_a_single_transformed_relation_resource(): void

--- a/tests/Feature/Relations/HasOne/HasOneRelationStandardUpdateOperationsTest.php
+++ b/tests/Feature/Relations/HasOne/HasOneRelationStandardUpdateOperationsTest.php
@@ -3,8 +3,6 @@
 namespace Orion\Tests\Feature\Relations\HasOne;
 
 use Illuminate\Support\Facades\Gate;
-use Mockery;
-use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Feature\TestCase;
 use Orion\Tests\Fixtures\App\Http\Requests\PostMetaRequest;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;

--- a/tests/Feature/StandardDeleteOperationsTest.php
+++ b/tests/Feature/StandardDeleteOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
@@ -206,6 +208,10 @@ class StandardDeleteOperationsTest extends TestCase
     /** @test */
     public function deleting_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $user = factory(User::class)->create();
         $post = factory(Post::class)->create(['user_id' => $user->id]);
 

--- a/tests/Feature/StandardDeleteOperationsTest.php
+++ b/tests/Feature/StandardDeleteOperationsTest.php
@@ -209,6 +209,7 @@ class StandardDeleteOperationsTest extends TestCase
     public function deleting_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/StandardDeleteOperationsTest.php
+++ b/tests/Feature/StandardDeleteOperationsTest.php
@@ -200,7 +200,7 @@ class StandardDeleteOperationsTest extends TestCase
 
         $response = $this->delete("/api/v1/posts/$post->id");
 
-        $this->assertResourceShown($response, $post);
+        $this->assertResourceTrashed($response, $post);
     }
 
     /** @test */

--- a/tests/Feature/StandardIncludeOperationsTest.php
+++ b/tests/Feature/StandardIncludeOperationsTest.php
@@ -106,7 +106,7 @@ class StandardIncludeOperationsTest extends TestCase
 
         $this->assertResourcesPaginated(
             $response,
-            $this->makePaginator([$user->load(['posts'])->toArray(),], 'users/search'),
+            $this->makePaginator([$user->load(['posts'])->toArray()], 'users/search'),
             [],
             false
         );

--- a/tests/Feature/StandardIndexFilteringOperationsTest.php
+++ b/tests/Feature/StandardIndexFilteringOperationsTest.php
@@ -681,7 +681,7 @@ class StandardIndexFilteringOperationsTest extends TestCase
     {
         $user = factory(User::class)->create(['name' => 'John Doe']);
         $matchingPost = factory(Post::class)
-            ->create([ 'user_id' => $user->id, ])->fresh();
+            ->create(['user_id' => $user->id])->fresh();
         factory(PostMeta::class)->create(['post_id' => $matchingPost->id, 'name' => 'test']);
 
         factory(Post::class)->create(['publish_at' => Carbon::now()])->fresh();
@@ -708,9 +708,8 @@ class StandardIndexFilteringOperationsTest extends TestCase
     public function getting_a_list_of_resources_filtered_by_identically_named_fields_on_different_nesting_level(): void
     {
         $matchingPost = factory(Post::class)
-            ->create(['title' => 'test' ])->fresh();
+            ->create(['title' => 'test'])->fresh();
         factory(PostMeta::class)->create(['post_id' => $matchingPost->id, 'title' => 'test']);
-
 
         factory(Post::class)->create(['publish_at' => Carbon::now()])->fresh();
 

--- a/tests/Feature/StandardIndexOperationsTest.php
+++ b/tests/Feature/StandardIndexOperationsTest.php
@@ -5,7 +5,6 @@ namespace Orion\Tests\Feature;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
-use Orion\Exceptions\MaxPaginationLimitExceededException;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleCollectionResource;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\Post;

--- a/tests/Feature/StandardRestoreOperationsTest.php
+++ b/tests/Feature/StandardRestoreOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
@@ -128,6 +130,10 @@ class StandardRestoreOperationsTest extends TestCase
     /** @test */
     public function restoring_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $trashedPost = factory(Post::class)->state('trashed')->create(['user_id' => factory(User::class)->create()->id]);
 
         Gate::policy(Post::class, GreenPolicy::class);

--- a/tests/Feature/StandardRestoreOperationsTest.php
+++ b/tests/Feature/StandardRestoreOperationsTest.php
@@ -131,6 +131,7 @@ class StandardRestoreOperationsTest extends TestCase
     public function restoring_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/StandardShowOperationsTest.php
+++ b/tests/Feature/StandardShowOperationsTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
 use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
-use Orion\Tests\Fixtures\App\Http\Resources\SampleCollectionResource;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\AccessKey;
 use Orion\Tests\Fixtures\App\Models\Comment;
@@ -174,23 +173,25 @@ class StandardShowOperationsTest extends TestCase
     {
         $this->useKeyResolver(TwoRouteParameterKeyResolver::class);
 
-        $team = factory(Team::class)->create();
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create(['user_id' => $user->id]);
 
-        Gate::policy(Team::class, GreenPolicy::class);
+        Gate::policy(Post::class, GreenPolicy::class);
 
-        $response = $this->get("/api/v1/teams/$team->id");
+        $response = $this->get("/api/v1/posts/$post->id");
 
-        $this->assertResourceShown($response, $team->fresh()->toArray());
+        $this->assertResourceShown($response, $post);
     }
 
     /** @test */
     public function getting_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
-        $team = factory(Team::class)->create();
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create(['user_id' => $user->id]);
 
-        Gate::policy(Team::class, GreenPolicy::class);
+        Gate::policy(Post::class, GreenPolicy::class);
 
-        $response = $this->get("/api/v1/teams/$team->id");
+        $response = $this->get("/api/v1/posts/$post->id");
 
         $response->assertNotFound();
     }

--- a/tests/Feature/StandardShowOperationsTest.php
+++ b/tests/Feature/StandardShowOperationsTest.php
@@ -5,6 +5,8 @@ namespace Orion\Tests\Feature;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
+use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
+use Orion\Tests\Fixtures\App\Http\Resources\SampleCollectionResource;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\AccessKey;
 use Orion\Tests\Fixtures\App\Models\Comment;
@@ -165,5 +167,31 @@ class StandardShowOperationsTest extends TestCase
         $response = $this->get("/api/teams/{$team->id}?include=company");
 
         $this->assertResourceShown($response, $team->fresh('company')->toArray());
+    }
+
+    /** @test */
+    public function getting_a_single_resource_with_multiple_route_parameters(): void
+    {
+        $this->useKeyResolver(TwoRouteParameterKeyResolver::class);
+
+        $team = factory(Team::class)->create();
+
+        Gate::policy(Team::class, GreenPolicy::class);
+
+        $response = $this->get("/api/v1/teams/$team->id");
+
+        $this->assertResourceShown($response, $team->fresh()->toArray());
+    }
+
+    /** @test */
+    public function getting_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
+    {
+        $team = factory(Team::class)->create();
+
+        Gate::policy(Team::class, GreenPolicy::class);
+
+        $response = $this->get("/api/v1/teams/$team->id");
+
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/StandardShowOperationsTest.php
+++ b/tests/Feature/StandardShowOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
@@ -186,6 +188,10 @@ class StandardShowOperationsTest extends TestCase
     /** @test */
     public function getting_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $user = factory(User::class)->create();
         $post = factory(Post::class)->create(['user_id' => $user->id]);
 

--- a/tests/Feature/StandardShowOperationsTest.php
+++ b/tests/Feature/StandardShowOperationsTest.php
@@ -189,6 +189,7 @@ class StandardShowOperationsTest extends TestCase
     public function getting_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/StandardUpdateOperationsTest.php
+++ b/tests/Feature/StandardUpdateOperationsTest.php
@@ -5,6 +5,7 @@ namespace Orion\Tests\Feature;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
+use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
 use Orion\Tests\Fixtures\App\Http\Requests\PostRequest;
 use Orion\Tests\Fixtures\App\Http\Resources\SampleResource;
 use Orion\Tests\Fixtures\App\Models\AccessKey;
@@ -157,5 +158,35 @@ class StandardUpdateOperationsTest extends TestCase
             $payload,
             ['user' => $user->fresh()->toArray()]
         );
+    }
+
+    /** @test */
+    public function updating_a_single_resource_with_multiple_route_parameters(): void
+    {
+        $this->useKeyResolver(TwoRouteParameterKeyResolver::class);
+
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create(['user_id' => $user->id]);
+        $payload = ['title' => 'test post title updated'];
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->patch("/api/v1/posts/$post->id", $payload);
+
+        $this->assertResourceShown($response, $post);
+    }
+
+    /** @test */
+    public function updating_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
+    {
+        $user = factory(User::class)->create();
+        $post = factory(Post::class)->create(['user_id' => $user->id]);
+        $payload = ['title' => 'test post title updated'];
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->patch("/api/v1/posts/$post->id", $payload);
+
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/StandardUpdateOperationsTest.php
+++ b/tests/Feature/StandardUpdateOperationsTest.php
@@ -2,6 +2,8 @@
 
 namespace Orion\Tests\Feature;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
@@ -184,6 +186,10 @@ class StandardUpdateOperationsTest extends TestCase
     /** @test */
     public function updating_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->expectException(QueryException::class);
+        }
+
         $user = factory(User::class)->create();
         $post = factory(Post::class)->create(['user_id' => $user->id]);
         $payload = ['title' => 'test post title updated'];

--- a/tests/Feature/StandardUpdateOperationsTest.php
+++ b/tests/Feature/StandardUpdateOperationsTest.php
@@ -173,7 +173,12 @@ class StandardUpdateOperationsTest extends TestCase
 
         $response = $this->patch("/api/v1/posts/$post->id", $payload);
 
-        $this->assertResourceShown($response, $post);
+        $this->assertResourceUpdated(
+            $response,
+            Post::class,
+            $post->toArray(),
+            $payload
+        );
     }
 
     /** @test */

--- a/tests/Feature/StandardUpdateOperationsTest.php
+++ b/tests/Feature/StandardUpdateOperationsTest.php
@@ -187,6 +187,7 @@ class StandardUpdateOperationsTest extends TestCase
     public function updating_a_single_resource_with_multiple_route_parameters_fails_with_default_key_resolver(): void
     {
         if (DB::connection()->getDriverName() === 'pgsql') {
+            $this->withoutExceptionHandling();
             $this->expectException(QueryException::class);
         }
 

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -4,15 +4,17 @@ namespace Orion\Tests\Feature;
 
 use Mockery;
 use Orion\Contracts\ComponentsResolver;
+use Orion\Contracts\KeyResolver;
 use Orion\Testing\InteractsWithAuthorization;
 use Orion\Testing\InteractsWithJsonFields;
 use Orion\Testing\InteractsWithResources;
+use Orion\Tests\Fixtures\App\Drivers\TwoRouteParameterKeyResolver;
 use Orion\Tests\Fixtures\App\Models\User;
 use Orion\Tests\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use InteractsWithResources, InteractsWithJsonFields, InteractsWithAuthorization;
+    use InteractsWithAuthorization, InteractsWithJsonFields, InteractsWithResources;
 
     protected function setUp(): void
     {
@@ -82,6 +84,16 @@ abstract class TestCase extends BaseTestCase
 
                 return $componentsResolverMock;
             }
+        );
+
+        return $this;
+    }
+
+    protected function useKeyResolver(string $keyResolverClass): self
+    {
+        app()->bind(
+            KeyResolver::class,
+            TwoRouteParameterKeyResolver::class
         );
 
         return $this;

--- a/tests/Fixtures/app/Drivers/TwoRouteParameterKeyResolver.php
+++ b/tests/Fixtures/app/Drivers/TwoRouteParameterKeyResolver.php
@@ -19,6 +19,6 @@ class TwoRouteParameterKeyResolver implements KeyResolver
 
     public function resolveRelationOperationRelatedKey(Request $request, array $args)
     {
-        return $args[2];
+        return $args[2] ?? null;
     }
 }

--- a/tests/Fixtures/app/Drivers/TwoRouteParameterKeyResolver.php
+++ b/tests/Fixtures/app/Drivers/TwoRouteParameterKeyResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Orion\Tests\Fixtures\App\Drivers;
+
+use Illuminate\Http\Request;
+use Orion\Contracts\KeyResolver;
+
+class TwoRouteParameterKeyResolver implements KeyResolver
+{
+    public function resolveStandardOperationKey(Request $request, array $args)
+    {
+        return $args[1];
+    }
+
+    public function resolveRelationOperationParentKey(Request $request, array $args)
+    {
+        return $args[1];
+    }
+
+    public function resolveRelationOperationRelatedKey(Request $request, array $args)
+    {
+        return $args[2];
+    }
+}

--- a/tests/Fixtures/app/Providers/OrionServiceProvider.php
+++ b/tests/Fixtures/app/Providers/OrionServiceProvider.php
@@ -5,6 +5,7 @@ namespace Orion\Tests\Fixtures\App\Providers;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 use Orion\Contracts\ComponentsResolver;
+use Orion\Contracts\KeyResolver;
 use Orion\Contracts\Paginator;
 use Orion\Contracts\ParamsValidator;
 use Orion\Contracts\QueryBuilder;
@@ -31,6 +32,7 @@ class OrionServiceProvider extends ServiceProvider
         $this->app->bind(Paginator::class, \Orion\Drivers\Standard\Paginator::class);
         $this->app->bind(SearchBuilder::class, \Orion\Drivers\Standard\SearchBuilder::class);
         $this->app->bind(ComponentsResolver::class, \Orion\Drivers\Standard\ComponentsResolver::class);
+        $this->app->bind(KeyResolver::class, \Orion\Drivers\Standard\KeyResolver::class);
 
         $this->app->singleton(ResourcesCacheStore::class);
     }

--- a/tests/Fixtures/routes/api.php
+++ b/tests/Fixtures/routes/api.php
@@ -39,5 +39,9 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
 
         Orion::belongsToResource('posts', 'user', PostUserController::class);
         Orion::belongsToResource('posts', 'category', PostCategoryController::class)->withSoftDeletes();
+
+        Orion::hasManyResource('companies', 'teams', CompanyTeamsController::class);
+
+        Orion::belongsToManyResource('users', 'roles', UserRolesController::class);
     });
 });

--- a/tests/Fixtures/routes/api.php
+++ b/tests/Fixtures/routes/api.php
@@ -33,4 +33,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
     Orion::hasManyResource('access_keys', 'scopes', AccessKeyAccessKeyScopesController::class)->withSoftDeletes();
     Orion::belongsToManyResource('users', 'roles', UserRolesController::class);
     Orion::belongsToManyResource('users', 'notifications', UserNotificationsController::class)->withSoftDeletes();
+
+    Route::group(['prefix' => '{apiVersion}'], function () {
+        Orion::resource('teams', TeamsController::class);
+    });
 });

--- a/tests/Fixtures/routes/api.php
+++ b/tests/Fixtures/routes/api.php
@@ -35,6 +35,6 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
     Orion::belongsToManyResource('users', 'notifications', UserNotificationsController::class)->withSoftDeletes();
 
     Route::group(['prefix' => '{apiVersion}'], function () {
-        Orion::resource('teams', TeamsController::class);
+        Orion::resource('posts', PostsController::class)->withSoftDeletes();
     });
 });

--- a/tests/Fixtures/routes/api.php
+++ b/tests/Fixtures/routes/api.php
@@ -36,5 +36,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
 
     Route::group(['prefix' => '{apiVersion}'], function () {
         Orion::resource('posts', PostsController::class)->withSoftDeletes();
+
+        Orion::belongsToResource('posts', 'user', PostUserController::class);
+        Orion::belongsToResource('posts', 'category', PostCategoryController::class)->withSoftDeletes();
     });
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         parent::setUp();
 
         $this->withFactories(__DIR__ . '/Fixtures/database/factories');
-        $this->withoutExceptionHandling();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         parent::setUp();
 
         $this->withFactories(__DIR__ . '/Fixtures/database/factories');
+        $this->withoutExceptionHandling();
     }
 
     /**

--- a/tests/Unit/Http/Controllers/BaseControllerTest.php
+++ b/tests/Unit/Http/Controllers/BaseControllerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\App;
 use Mockery;
 use Orion\Drivers\Standard\ComponentsResolver;
+use Orion\Drivers\Standard\KeyResolver;
 use Orion\Drivers\Standard\Paginator;
 use Orion\Drivers\Standard\ParamsValidator;
 use Orion\Drivers\Standard\QueryBuilder;
@@ -25,7 +26,6 @@ use Orion\Tests\Unit\TestCase;
 
 class BaseControllerTest extends TestCase
 {
-
     /** @test */
     public function binding_exception_is_thrown_if_model_is_not_set()
     {
@@ -44,6 +44,7 @@ class BaseControllerTest extends TestCase
         $fakePaginator = new Paginator(15, null);
         $fakeSearchBuilder = new SearchBuilder([]);
         $fakeQueryBuilder = new QueryBuilder(Post::class, $fakeParamsValidator, $fakeRelationsResolver, $fakeSearchBuilder);
+        $fakeKeyResolver = new KeyResolver();
 
         App::shouldReceive('makeWith')->with(
             \Orion\Contracts\ComponentsResolver::class,
@@ -96,6 +97,10 @@ class BaseControllerTest extends TestCase
                 'intermediateMode' => false,
             ]
         )->once()->andReturn($fakeQueryBuilder);
+
+        App::shouldReceive('make')->with(
+            \Orion\Contracts\KeyResolver::class,
+        )->once()->andReturn($fakeKeyResolver);
 
         $stub = new BaseControllerStubWithWhitelistedFieldsAndRelations();
         $this->assertEquals($fakeComponentsResolver, $stub->getComponentsResolver());

--- a/tests/Unit/Http/Controllers/RelationControllerTest.php
+++ b/tests/Unit/Http/Controllers/RelationControllerTest.php
@@ -5,6 +5,7 @@ namespace Orion\Tests\Unit\Http\Controllers;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\App;
 use Orion\Drivers\Standard\ComponentsResolver;
+use Orion\Drivers\Standard\KeyResolver;
 use Orion\Drivers\Standard\Paginator;
 use Orion\Drivers\Standard\ParamsValidator;
 use Orion\Drivers\Standard\QueryBuilder;
@@ -39,6 +40,7 @@ class RelationControllerTest extends TestCase
         $fakeSearchBuilder = new SearchBuilder([]);
         $fakeQueryBuilder = new QueryBuilder(Post::class, $fakeParamsValidator, $fakeRelationsResolver, $fakeSearchBuilder);
         $fakeRelationQueryBuilder = new QueryBuilder(User::class, $fakeParamsValidator, $fakeRelationsResolver, $fakeSearchBuilder);
+        $fakeKeyResolver = new KeyResolver();
 
         App::shouldReceive('makeWith')->with(
             \Orion\Contracts\ComponentsResolver::class,
@@ -108,6 +110,10 @@ class RelationControllerTest extends TestCase
                 'searchBuilder' => $fakeSearchBuilder,
             ]
         )->once()->andReturn($fakeRelationQueryBuilder);
+
+        App::shouldReceive('make')->with(
+            \Orion\Contracts\KeyResolver::class,
+        )->once()->andReturn($fakeKeyResolver);
 
         $stub = new RelationControllerStub();
         $this->assertEquals($fakeComponentsResolver, $stub->getComponentsResolver());


### PR DESCRIPTION
This PR aims to one, add a new feature, while two, allow more use cases for this package. Currently, when defining resources, if the route has another route parameter included, the package will not resolve the correct route parameter within the controller function definitions. Currently they are hardcoded to not allow more route parameters. 

The current user story I am trying to fix with this PR is to define API routes like such: `https://xxxxxx.com/api/{apiVersion}/users/{id}`. 

We want our end users to be able to specify the API version using a route parameter. Within our application, we look at `apiVersion` and determine which HTTP resource to return to them.

In the current state of the package, within the `HandlesStandardOperations::show($request, $key)` method, `$key` will resolve to, in our user story, `v1`, instead of the `User` ID. 

To fix this, we have introduced a backwards compatible key resolver that changes the function definition to `HandlesStandardOperations::show($request, ...$args)` to allow multiple route parameters to be resolved. Within a bound `KeyResolver` class in the container, some simple logic is done to return which parameter should be used as the `$key` for the further operations.

If a user needs to customize the `KeyResolver`, they simply bind a new instance of their own custom implementation. I have included tests to illustrate.