### PR TITLE
Fix - Specs property nullable issue which was reversed in PropertyBuilder

### DIFF
--- a/src/Specs/Builders/PropertyBuilder.php
+++ b/src/Specs/Builders/PropertyBuilder.php
@@ -19,7 +19,7 @@ class PropertyBuilder
         /** @var SchemaProperty $property */
         $property = new $concretePropertyClass();
         $property->name = $column['name'];
-        $property->nullable = !$column['nullable'];
+        $property->nullable = $column['nullable'];
 
         return $property;
     }

--- a/tests/Unit/Specs/Builders/PropertyBuilderTest.php
+++ b/tests/Unit/Specs/Builders/PropertyBuilderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orion\Tests\Unit\Specs\Builders;
+
+use Orion\Specs\Builders\PathsBuilder;
+use Orion\Specs\Builders\PropertyBuilder;
+use Orion\Tests\Unit\TestCase;
+use Orion\ValueObjects\Specs\Schema\SchemaProperty;
+
+class PropertyBuilderTest extends TestCase
+{
+    /**
+     * @var PathsBuilder
+     */
+    protected $pathsBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pathsBuilder = app()->make(PathsBuilder::class);
+    }
+
+    /** @test */
+    public function building_property(): void
+    {
+        $column = [
+            'name' => 'example_column',
+            'nullable' => true,
+        ];
+        $concretePropertyClass = 'Orion\ValueObjects\Specs\Schema\SchemaProperty';
+
+        $propertyBuilder = new PropertyBuilder();
+        $property = $propertyBuilder->build($column, $concretePropertyClass);
+
+        $this->assertInstanceOf(SchemaProperty::class, $property);
+        $this->assertEquals($column['name'], $property->name);
+        $this->assertEquals($column['nullable'], $property->nullable);
+    }
+}
+
+


### PR DESCRIPTION
Fixed issue where the specs incorrectly marked a field as non-nullable. The issue was introduced when it was an object with getNotNull function then was changed to an array with a nullable property. 
Issue reference: https://github.com/tailflow/laravel-orion/commit/e3e5b657f280901bb1d76892d5ffbcd2df3e3347#diff-1d3d225dd65e11ca23b0f59cc7f32929e6421b4bcbfe6be3ce3e67b958640a86R22