### PR TITLE
Replace `request->get()` with `request->input()` for better consistency and clarity.

### DIFF
--- a/src/Concerns/HandlesRelationManyToManyOperations.php
+++ b/src/Concerns/HandlesRelationManyToManyOperations.php
@@ -57,7 +57,7 @@ trait HandlesRelationManyToManyOperations
             $request,
             $parentEntity,
             $this->retrieve($request, 'resources'),
-            $request->get('duplicates', false)
+            $request->boolean('duplicates')
         );
 
         $afterHookResult = $this->afterAttach($request, $parentEntity, $attachResult);
@@ -404,7 +404,7 @@ trait HandlesRelationManyToManyOperations
             $request,
             $parentEntity,
             $this->retrieve($request, 'resources'),
-            $request->get('detaching', true)
+            $request->boolean('detaching', true)
         );
 
         $afterHookResult = $this->afterSync($request, $parentEntity, $syncResult);
@@ -652,7 +652,7 @@ trait HandlesRelationManyToManyOperations
 
         $this->authorize($this->resolveAbility('update'), [$entity, $parentEntity]);
 
-        $updateResult = $this->performUpdatePivot($request, $parentEntity, $relatedKey, $request->get('pivot', []));
+        $updateResult = $this->performUpdatePivot($request, $parentEntity, $relatedKey, $request->input('pivot', []));
 
         $afterHookResult = $this->afterUpdatePivot($request, $parentEntity, $updateResult);
         if ($this->hookResponds($afterHookResult)) {

--- a/src/Concerns/HandlesRelationOneToManyOperations.php
+++ b/src/Concerns/HandlesRelationOneToManyOperations.php
@@ -46,7 +46,7 @@ trait HandlesRelationOneToManyOperations
         $requestedRelations = $this->relationsResolver->requestedRelations($request);
 
         $query = $this->buildAssociateFetchQuery($request, $parentEntity, $requestedRelations);
-        $entity = $this->runAssociateFetchQuery($request, $query, $parentEntity, $request->get('related_key'));
+        $entity = $this->runAssociateFetchQuery($request, $query, $parentEntity, $request->input('related_key'));
 
         $beforeHookResult = $this->beforeAssociate($request, $parentEntity, $entity);
         if ($this->hookResponds($beforeHookResult)) {
@@ -58,7 +58,7 @@ trait HandlesRelationOneToManyOperations
 
         $this->performAssociate($request, $parentEntity, $entity);
 
-        $entity = $this->runAssociateFetchQuery($request, $query, $parentEntity, $request->get('related_key'));
+        $entity = $this->runAssociateFetchQuery($request, $query, $parentEntity, $request->input('related_key'));
 
         $afterHookResult = $this->afterAssociate($request, $parentEntity, $entity);
         if ($this->hookResponds($afterHookResult)) {

--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -153,7 +153,7 @@ trait HandlesRelationStandardOperations
      */
     protected function buildIndexFetchQuery(Request $request, Model $parentEntity, array $requestedRelations): Relation
     {
-        $filters = collect($request->get('filters', []))
+        $filters = collect($request->input('filters', []))
             ->map(function (array $filterDescriptor) use ($request, $parentEntity) {
                 return $this->beforeFilterApplied($request, $parentEntity, $filterDescriptor);
             })->toArray();
@@ -320,7 +320,7 @@ trait HandlesRelationStandardOperations
             $parentEntity,
             $entity,
             $this->retrieve($request),
-            $request->get('pivot', [])
+            $request->input('pivot', [])
         );
 
         $query = $this->buildStoreFetchQuery($request, $parentEntity, $requestedRelations);
@@ -732,7 +732,7 @@ trait HandlesRelationStandardOperations
             $parentEntity,
             $entity,
             $this->retrieve($request),
-            $request->get('pivot', [])
+            $request->input('pivot', [])
         );
 
         $entity = $this->refreshUpdatedEntity(

--- a/src/Concerns/HandlesScopedFilters.php
+++ b/src/Concerns/HandlesScopedFilters.php
@@ -22,7 +22,7 @@ trait HandlesScopedFilters
      */
     public function resolveScopedFilters($query, Request $request, array $mappingCallbacks): array
     {
-        $requestedFilters = $request->get('filters', []);
+        $requestedFilters = $request->input('filters', []);
 
         $filters = $this->getScopedFilterDescriptors(collect($requestedFilters));
 

--- a/src/Concerns/HandlesStandardOperations.php
+++ b/src/Concerns/HandlesStandardOperations.php
@@ -62,7 +62,7 @@ trait HandlesStandardOperations
      */
     protected function buildIndexFetchQuery(Request $request, array $requestedRelations): Builder
     {
-        $filters = collect($request->get('filters', []))
+        $filters = collect($request->input('filters', []))
             ->map(function (array $filterDescriptor) use ($request) {
                 return $this->beforeFilterApplied($request, $filterDescriptor);
             })->toArray();

--- a/src/Concerns/InteractsWithBatchResources.php
+++ b/src/Concerns/InteractsWithBatchResources.php
@@ -12,7 +12,7 @@ trait InteractsWithBatchResources
      */
     protected function resolveResourceKeys(Request $request): array
     {
-        $resources = $request->get('resources', []);
+        $resources = $request->input('resources', []);
         if (array_keys($resources) !== range(0, count($resources) - 1)) {
             return array_keys($resources);
         }

--- a/src/Drivers/Standard/Paginator.php
+++ b/src/Drivers/Standard/Paginator.php
@@ -37,7 +37,7 @@ class Paginator implements \Orion\Contracts\Paginator
      */
     public function resolvePaginationLimit(Request $request): int
     {
-        $limit = (int) $request->get('limit');
+        $limit = (int) $request->input('limit');
 
         return tap($limit > 0 ? $limit : $this->defaultLimit, function ($limit) {
             if ($this->maxLimit && $limit > $this->maxLimit) {

--- a/src/Drivers/Standard/QueryBuilder.php
+++ b/src/Drivers/Standard/QueryBuilder.php
@@ -98,7 +98,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
     public function applyScopesToQuery($query, Request $request): void
     {
         $this->paramsValidator->validateScopes($request);
-        $scopeDescriptors = $request->get('scopes', []);
+        $scopeDescriptors = $request->input('scopes', []);
 
         foreach ($scopeDescriptors as $scopeDescriptor) {
             $query->{$scopeDescriptor['name']}(...Arr::get($scopeDescriptor, 'parameters', []));
@@ -118,7 +118,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         if (!$filterDescriptors && !$this->intermediateMode) {
             $this->paramsValidator->validateFilters($request);
 
-            $filterDescriptors = $request->get('filters', []);
+            $filterDescriptors = $request->input('filters', []);
         }
 
         foreach ($filterDescriptors as $filterDescriptor) {
@@ -381,7 +381,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
      */
     public function applySearchingToQuery($query, Request $request): void
     {
-        if (!$requestedSearchDescriptor = $request->get('search')) {
+        if (!$requestedSearchDescriptor = $request->input('search')) {
             return;
         }
 
@@ -461,7 +461,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
     public function applySortingToQuery($query, Request $request): void
     {
         $this->paramsValidator->validateSort($request);
-        $sortableDescriptors = $request->get('sort', []);
+        $sortableDescriptors = $request->input('sort', []);
 
         foreach ($sortableDescriptors as $sortable) {
             $sortableField = $sortable['field'];
@@ -561,7 +561,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
                 );
             }
 
-            $aggregateDescriptors = $aggregateDescriptors->merge($request->get('aggregates', []));
+            $aggregateDescriptors = $aggregateDescriptors->merge($request->input('aggregates', []));
         }
 
         foreach ($aggregateDescriptors as $aggregateDescriptor) {
@@ -618,7 +618,7 @@ class QueryBuilder implements \Orion\Contracts\QueryBuilder
         if (!$includeDescriptors) {
             $this->paramsValidator->validateIncludes($request);
 
-            $requestedIncludeDescriptors = collect($request->get('includes', []));
+            $requestedIncludeDescriptors = collect($request->input('includes', []));
 
             $includeDescriptors = collect($this->relationsResolver->requestedRelations($request))
                 ->map(function ($include) use ($requestedIncludeDescriptors) {

--- a/src/Drivers/Standard/RelationsResolver.php
+++ b/src/Drivers/Standard/RelationsResolver.php
@@ -44,7 +44,7 @@ class RelationsResolver implements \Orion\Contracts\RelationsResolver
     public function requestedRelations(Request $request): array
     {
         $requestedIncludesQuery = collect(explode(',', $request->query('include', '')));
-        $requestedIncludesBody = collect($request->get('includes', []))->pluck('relation');
+        $requestedIncludesBody = collect($request->input('includes', []))->pluck('relation');
 
         $requestedIncludes = $requestedIncludesQuery
             ->merge($requestedIncludesBody)


### PR DESCRIPTION
 **Summary**
                                                                                                                                                                            
  - Replace all deprecated $request->get() calls (Symfony ParameterBag::get()) with Laravel's typed request accessors (->input(), ->boolean())                            
  - Resolves Symfony 7.4+ deprecation warnings that surface in PHPStan and Telescope logs                                                                                   
                                                                                                                                                                            
  **Context**                                                                                                                                                                   
                                                                                                                                                                            
  Symfony 7.4 deprecated `Request::get()`, producing warnings like:                                                                                                           
  `Request::get()` is deprecated, use properties ->attributes, query or request directly instead.

  These warnings appear in PHPStan analysis and flood Telescope logs on every request.

  **Changes**

  - `$request->get('key', [])` → `$request->input('key', [])` for array values                                                                                                  
  - `$request->get('key', false)` → `$request->boolean('key')` for boolean values
  - `(int) $request->get('key')` → `(int) $request->input('key')` for integer values                                                                                            
  - `$request->get('key')` → `$request->input('key')` for scalar values                                                                                                         
                                                                                                                                                                            
  Used ->input() rather than ->array() / ->integer() to maintain backward compatibility with Laravel 8–11, since those methods were only introduced in Laravel 11+/12.      
       