### PR TITLE
fix: apply rewritten filters from beforeFilterApplied on JSON requests

### DIFF
--- a/src/Concerns/HandlesRelationStandardOperations.php
+++ b/src/Concerns/HandlesRelationStandardOperations.php
@@ -158,7 +158,11 @@ trait HandlesRelationStandardOperations
                 return $this->beforeFilterApplied($request, $parentEntity, $filterDescriptor);
             })->toArray();
 
-        $request->request->add(['filters' => $filters]);
+        if ($request->isJson()) {
+            $request->json()->set('filters', $filters);
+        } else {
+            $request->request->set('filters', $filters);
+        }
 
         return $this->buildRelationFetchQuery($request, $parentEntity, $requestedRelations);
     }

--- a/src/Concerns/HandlesStandardOperations.php
+++ b/src/Concerns/HandlesStandardOperations.php
@@ -67,7 +67,11 @@ trait HandlesStandardOperations
                 return $this->beforeFilterApplied($request, $filterDescriptor);
             })->toArray();
 
-        $request->request->add(['filters' => $filters]);
+        if ($request->isJson()) {
+            $request->json()->set('filters', $filters);
+        } else {
+            $request->request->set('filters', $filters);
+        }
 
         return $this->buildFetchQuery($request, $requestedRelations);
     }

--- a/tests/Feature/StandardIndexBeforeFilterAppliedOperationsTest.php
+++ b/tests/Feature/StandardIndexBeforeFilterAppliedOperationsTest.php
@@ -13,7 +13,7 @@ class StandardIndexBeforeFilterAppliedOperationsTest extends TestCase
     public function filters_rewritten_in_before_filter_applied_take_effect_for_json_requests(): void
     {
         $matchingPost = factory(Post::class)->create(['title' => 'match', 'body' => 'no match'])->fresh();
-        $nonMatchingPost = factory(Post::class)->create(['title' => 'no match', 'body' => 'match'])->fresh();
+        factory(Post::class)->create(['title' => 'no match', 'body' => 'match'])->fresh();
 
         Gate::policy(Post::class, GreenPolicy::class);
 
@@ -34,9 +34,6 @@ class StandardIndexBeforeFilterAppliedOperationsTest extends TestCase
         $response->assertOk();
         $response->assertJsonCount(1, 'data');
         $response->assertJsonPath('data.0.id', $matchingPost->id);
-        $response->assertJsonMissingPath('data.1');
-
-        $this->assertNotEquals($matchingPost->id, $nonMatchingPost->id);
     }
 
     /** @test */

--- a/tests/Feature/StandardIndexBeforeFilterAppliedOperationsTest.php
+++ b/tests/Feature/StandardIndexBeforeFilterAppliedOperationsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Orion\Tests\Feature;
+
+use Illuminate\Support\Facades\Gate;
+use Orion\Tests\Fixtures\App\Models\Post;
+use Orion\Tests\Fixtures\App\Models\User;
+use Orion\Tests\Fixtures\App\Policies\GreenPolicy;
+
+class StandardIndexBeforeFilterAppliedOperationsTest extends TestCase
+{
+    /** @test */
+    public function filters_rewritten_in_before_filter_applied_take_effect_for_json_requests(): void
+    {
+        $matchingPost = factory(Post::class)->create(['title' => 'match', 'body' => 'no match'])->fresh();
+        $nonMatchingPost = factory(Post::class)->create(['title' => 'no match', 'body' => 'match'])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->json(
+            'POST',
+            '/api/posts_before_filter/search',
+            [
+                'filters' => [
+                    ['field' => 'body', 'value' => 'match'],
+                ],
+            ]
+        );
+
+        // The controller rewrites the "body" filter onto the "title" column, so
+        // only the post whose title is "match" should be returned. Before the fix
+        // the rewrite was written to the POST bag while JSON requests read filters
+        // from the JSON bag, so the original "body" filter was applied instead.
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $matchingPost->id);
+        $response->assertJsonMissingPath('data.1');
+
+        $this->assertNotEquals($matchingPost->id, $nonMatchingPost->id);
+    }
+
+    /** @test */
+    public function filters_rewritten_in_before_filter_applied_take_effect_for_form_requests(): void
+    {
+        $matchingPost = factory(Post::class)->create(['title' => 'match', 'body' => 'no match'])->fresh();
+        factory(Post::class)->create(['title' => 'no match', 'body' => 'match'])->fresh();
+
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/posts_before_filter/search',
+            [
+                'filters' => [
+                    ['field' => 'body', 'value' => 'match'],
+                ],
+            ]
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $matchingPost->id);
+    }
+
+    /** @test */
+    public function relation_filters_rewritten_in_before_filter_applied_take_effect_for_json_requests(): void
+    {
+        $user = factory(User::class)->create();
+        $matchingPost = factory(Post::class)->create([
+            'user_id' => $user->id, 'title' => 'match', 'body' => 'no match',
+        ])->fresh();
+        factory(Post::class)->create([
+            'user_id' => $user->id, 'title' => 'no match', 'body' => 'match',
+        ])->fresh();
+
+        Gate::policy(User::class, GreenPolicy::class);
+        Gate::policy(Post::class, GreenPolicy::class);
+
+        $response = $this->json(
+            'POST',
+            "/api/users/{$user->id}/posts/search",
+            [
+                'filters' => [
+                    ['field' => 'body', 'value' => 'match'],
+                ],
+            ]
+        );
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+        $response->assertJsonPath('data.0.id', $matchingPost->id);
+    }
+}

--- a/tests/Fixtures/app/Http/Controllers/PostsBeforeFilterAppliedController.php
+++ b/tests/Fixtures/app/Http/Controllers/PostsBeforeFilterAppliedController.php
@@ -2,21 +2,16 @@
 
 namespace Orion\Tests\Fixtures\App\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Model;
-use Orion\Http\Controllers\RelationController;
+use Orion\Http\Controllers\Controller;
 use Orion\Http\Requests\Request;
-use Orion\Tests\Fixtures\App\Models\User;
+use Orion\Tests\Fixtures\App\Models\Post;
 
-class UserPostsController extends RelationController
+class PostsBeforeFilterAppliedController extends Controller
 {
-    protected $model = User::class;
-
-    protected $relation = 'posts';
-
-    public function includes(): array
-    {
-        return ['user'];
-    }
+    /**
+     * @var string|null $model
+     */
+    protected $model = Post::class;
 
     public function filterableBy(): array
     {
@@ -28,11 +23,10 @@ class UserPostsController extends RelationController
      * exercise filter rewriting inside buildIndexFetchQuery.
      *
      * @param Request $request
-     * @param Model $parentEntity
      * @param array $filterDescriptor
      * @return array
      */
-    protected function beforeFilterApplied(Request $request, Model $parentEntity, array $filterDescriptor): array
+    protected function beforeFilterApplied(Request $request, array $filterDescriptor): array
     {
         if (($filterDescriptor['field'] ?? null) === 'body') {
             $filterDescriptor['field'] = 'title';

--- a/tests/Fixtures/routes/api.php
+++ b/tests/Fixtures/routes/api.php
@@ -6,6 +6,7 @@ use Orion\Tests\Fixtures\App\Http\Controllers\AccessKeyAccessKeyScopesController
 use Orion\Tests\Fixtures\App\Http\Controllers\AccessKeysController;
 use Orion\Tests\Fixtures\App\Http\Controllers\CommentsController;
 use Orion\Tests\Fixtures\App\Http\Controllers\CompanyTeamsController;
+use Orion\Tests\Fixtures\App\Http\Controllers\PostsBeforeFilterAppliedController;
 use Orion\Tests\Fixtures\App\Http\Controllers\PostCategoryController;
 use Orion\Tests\Fixtures\App\Http\Controllers\PostPostImageController;
 use Orion\Tests\Fixtures\App\Http\Controllers\PostPostMetaController;
@@ -23,6 +24,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
     Orion::resource('access_keys', AccessKeysController::class)->withSoftDeletes();
     Orion::resource('users', UsersController::class);
     Orion::resource('comments', CommentsController::class);
+    Orion::resource('posts_before_filter', PostsBeforeFilterAppliedController::class);
 
     Orion::belongsToResource('posts', 'user', PostUserController::class);
     Orion::belongsToResource('posts', 'category', PostCategoryController::class)->withSoftDeletes();


### PR DESCRIPTION
## Problem

`buildIndexFetchQuery` reads filters via `$request->input('filters')` and runs each descriptor through `beforeFilterApplied()`, then writes the rewritten filters back with `$request->request->add(['filters' => $filters])`.

`$request->input()` resolves to the **JSON bag** for JSON requests, but the write targets the **request (POST) bag**. Downstream filter application (`QueryBuilder::applyFiltersToQuery`) also reads via `$request->input()`. So for JSON requests the rewrite lands in a bag nobody reads, and the **original** (un-rewritten) filters are applied instead.

This silently breaks any controller that rewrites filter descriptors in `beforeFilterApplied()` (e.g. mapping a client-facing field onto a relation column) whenever the client sends a JSON body — which is the common case for `/search`.

The mismatch was introduced when filter reads were standardized on `$request->input()`; the write in `buildIndexFetchQuery` was left on the request bag.

## Fix

Write the rewritten filters back to the bag that matches the input source:

```php
if ($request->isJson()) {
    $request->json()->set('filters', $filters);
} else {
    $request->request->set('filters', $filters);
}
```

Applied in both `HandlesStandardOperations` and `HandlesRelationStandardOperations`. Form-encoded requests are unaffected (`set()` on the request bag is equivalent to the previous `add()` for this single key).

## Tests

Adds `StandardIndexBeforeFilterAppliedOperationsTest` covering filter rewriting in `beforeFilterApplied()` over:
- a JSON request on a standard resource (failed before the fix),
- a form-encoded request on a standard resource (passed before — included as a control showing the bug is JSON-specific),
- a JSON request on a relation resource (failed before the fix).

Existing filtering tests only exercised form-encoded `post()`, which is why this went unnoticed. Each new test was verified to fail without the corresponding production change and pass with it; the full feature suite shows no regressions.